### PR TITLE
BV tck to 3.0.0-M5, Hibernate Validator to 7.0.0.Alpha4, arquillian s…

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -34,14 +34,14 @@ spec:
     - "localhost.localdomain"
   containers:
   - name: bv-tck-ci
-    image: anajosep/cts-base:0.1
+    image: jakartaee/cts-base:0.2
     command:
     - cat
     tty: true
     imagePullPolicy: Always
     env:
-      - name: JAVA_TOOL_OPTIONS
-        value: -Xmx2G
+    - name: JAVA_TOOL_OPTIONS
+      value: -Xmx2G
     resources:
       limits:
         memory: "8Gi"
@@ -51,19 +51,19 @@ spec:
   }
   parameters {
     string(name: 'GF_BUNDLE_URL', 
-             defaultValue: 'https://download.eclipse.org/ee4j/jakartaee-tck/8.0.1/nightly/glassfish.zip',
+             defaultValue: 'https://ci.eclipse.org/jakartaee-tck/job/build-glassfish/lastSuccessfulBuild/artifact/appserver/distributions/glassfish/target/glassfish.zip',
              description: 'URL required for downloading GlassFish Full/Web profile bundle' )
   	string(name: 'TCK_BUNDLE_BASE_URL',
               defaultValue: '',
               description: 'Base URL required for downloading prebuilt binary TCK Bundle from a hosted location' )
     string(name: 'TCK_BUNDLE_FILE_NAME', 
-             defaultValue: 'bv-tck-glassfish-porting-2.0.0.zip', 
+             defaultValue: 'bv-tck-glassfish-porting-3.0.0.zip', 
              description: 'Name of bundle file to be appended to the base url' )
     string(name: 'BV_TCK_BUNDLE_URL', 
-             defaultValue: 'http://download.eclipse.org/ee4j/bean-validation/beanvalidation-tck-dist-2.0.5.zip', 
+             defaultValue: 'http://download.eclipse.org/ee4j/bean-validation/3.0/beanvalidation-tck-dist-3.0.0-M5.zip', 
   	         description: 'BV TCK bundle url' )
     string(name: 'BV_TCK_VERSION', 
-             defaultValue: '2.0.5', 
+             defaultValue: '3.0.0', 
              description: 'version of bundle file' )
 
   }

--- a/build.xml
+++ b/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -88,7 +88,7 @@
         
 	<target name="run.all.tests" depends="sigtest, test"/>
 
-        <target name="test" depends="config.v4, copy.settingsxml, filter.arquillian.xml">
+        <target name="test" depends="config.v4, filter.arquillian.xml">
             <if>
                 <or>
                  <os family="windows"/>
@@ -111,7 +111,7 @@
                 <java outputproperty="sigoutput" fork="true" jar="${lib}/sigtest.jar">
 			<arg value="Signaturetest"/>
                         <arg value="-Classpath"/>
-                        <arg value="${java.home}/${java.classes.for.sig.ext}${pathsep}${glassfish.home}/modules/bean-validator.jar${aix.jars}"/>
+                        <arg value="${java.home}/${java.classes.for.sig.ext}${pathsep}${glassfish.home}/modules/hibernate-validator.jar${aix.jars}"/>
                         <arg value="-Package"/>
                         <arg value="javax.validation"/>
                         <arg value="-FileName"/>
@@ -456,9 +456,11 @@
         
 	<presetdef name="mvn.test">
 		<exec executable="${maven.executable}">
+			<arg value="--global-settings" />
+			<arg value="${porting.home}/settings.xml"/>
 			<arg value="-U" />
-                        <arg value="clean" />
-                        <arg value="test" />
+            <arg value="clean" />
+            <arg value="test" />
 		</exec>
 	</presetdef>
         
@@ -466,8 +468,10 @@
 		<exec executable="cmd">
 			<arg value="/c"/>
                         <arg value="${maven.executable}.bat"/>
-                        <arg value="-U" />
-                        <arg value="test" />
+                        	<arg value="--global-settings" />
+							<arg value="${porting.home}/settings.xml"/>
+							<arg value="-U" />
+            				<arg value="test" />
 		</exec>
 	</presetdef>
         
@@ -475,7 +479,7 @@
 		<java fork="true" jar="${lib}/sigtestdev.jar">
 			<arg value="Setup"/>
                         <arg value="-Classpath"/>
-                        <arg value="${java.home}/${java.classes.for.sig.ext}:${glassfish.home}/modules/bean-validator.jar"/>
+                        <arg value="${java.home}/${java.classes.for.sig.ext}:${glassfish.home}/modules/hibernate-validator.jar"/>
                         <arg value="-Package"/>
                         <arg value="javax.validation"/>
                         <arg value="-FileName"/>

--- a/docker/build_bvtck.sh
+++ b/docker/build_bvtck.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -xe
 #
-# Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0, which is available at
@@ -33,7 +33,7 @@ mvn -version
 
 
 sed -i "s#^porting\.home=.*#porting.home=$WORKSPACE#g" "$WORKSPACE/build.xml"
-sed -i "s#^glassfish\.home=.*#glassfish.home=$WORKSPACE/glassfish5/glassfish#g" "$WORKSPACE/build.xml"
+sed -i "s#^glassfish\.home=.*#glassfish.home=$WORKSPACE/glassfish6/glassfish#g" "$WORKSPACE/build.xml"
 
 ant -version
 ant dist.sani
@@ -41,7 +41,7 @@ ant dist.sani
 mkdir -p ${WORKSPACE}/bundles
 if [ ! -z "$TCK_BUNDLE_BASE_URL" ]; then
   #use pre-built tck bundle from this location to run test
-  #mkdir -p ${WORKSPACE}/bundles
+  mkdir -p ${WORKSPACE}/bundles
   wget  --progress=bar:force --no-cache ${TCK_BUNDLE_BASE_URL}/${TCK_BUNDLE_FILE_NAME} -O ${WORKSPACE}/bundles/${TCK_BUNDLE_FILE_NAME}
   exit 0
 fi

--- a/glassfish-tck-runner/pom.xml
+++ b/glassfish-tck-runner/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
   ~ JBoss, Home of Professional Open Source
-  ~ Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual contributors
+  ~ Copyright 2011, 2020 Red Hat, Inc. and/or its affiliates, and individual contributors
   ~ by the @authors tag. See the copyright.txt in the distribution for a
   ~ full listing of individual contributors.
   ~
@@ -17,40 +17,55 @@
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
- 
     <parent>
-        <artifactId>hibernate-validator-parent</artifactId>
-        <groupId>org.hibernate.validator</groupId>
-        <version>6.0.17.Final</version>
+        <groupId>org.eclipse.ee4j</groupId>
+        <artifactId>project</artifactId>
+        <version>1.0.6</version>
     </parent>
-    <groupId>org.glassfish</groupId>
-    <version>6.0.17.Final</version>
-    <artifactId>hibernate-validator-tck-runner</artifactId>
- 
-    <name>Hibernate Validator TCK Runner</name>
-    <description>Aggregates dependencies and runs the BV TCK</description>
+	<groupId>jakarta.validation</groupId>
+    <artifactId>tck-runner</artifactId>
+    <version>3.0.0-M5</version>
+
+    <name>Jakarta Bean Validation TCK Runner</name>
+    <description>Aggregates dependencies and runs the Jakarta Bean Validation TCK</description>
  
     <properties>
-        <tck.version>2.0.5</tck.version>
-        <tck.suite.file>${project.build.directory}/dependency/beanvalidation-tck-tests.xml</tck.suite.file>
-        <arquillian.version>1.1.11.Final</arquillian.version>
+        <tck.suite.file>${project.build.directory}/dependency/beanvalidation-tck-tests-suite.xml</tck.suite.file>
+        <arquillian.version>1.7.0.Alpha2</arquillian.version>
         <jbossas.version>7.2.0.Final</jbossas.version>
         <jbossTargetDir>${project.build.directory}/jboss-as-${jbossas.version}</jbossTargetDir>
         <validation.provider>org.hibernate.validator.HibernateValidator</validation.provider>
         <remote.debug/>
-
-        <validation.api.version>2.0.2</validation.api.version>
-        <testng.version>6.9.9</testng.version>
+        <validation.api.version>3.0.0-M1</validation.api.version>
+        <testng.version>6.14.3</testng.version>
         <assertj-core.version>3.7.0</assertj-core.version>
         <shrinkwrap.descriptors.version>2.0.0-alpha-10</shrinkwrap.descriptors.version>
-
-        <cdi-api.version>2.0.1</cdi-api.version>
-        <jakarta.el.version>3.0.2</jakarta.el.version>
-        <jboss.test.audit.version>1.1.3.Final</jboss.test.audit.version>
-   
+        <cdi-api.version>3.0.0-M4</cdi-api.version>
+        <jakarta.el.version>4.0.0-RC2</jakarta.el.version>
+        <jboss.test.audit.version>1.1.4.Final</jboss.test.audit.version> 
     </properties>
- 
+ 	
     <dependencies>
+		<dependency>
+		    <groupId>org.jboss.arquillian.test</groupId>
+		    <artifactId>arquillian-test-spi</artifactId>
+		    <version>${arquillian.version}</version>
+		</dependency>
+		<dependency>
+		    <groupId>jakarta.platform</groupId>
+		    <artifactId>jakarta.jakartaee-api</artifactId>
+		    <version>9.0.0-RC2</version>
+		</dependency>
+		<dependency>
+    	<groupId>org.hibernate.validator</groupId>
+    		<artifactId>hibernate-validator-cdi</artifactId>
+    		<version>7.0.0.Alpha4</version>
+  		</dependency>
+		<dependency>
+		    <groupId>jakarta.ws.rs</groupId>
+		    <artifactId>jakarta.ws.rs-api</artifactId>
+		    <version>3.0.0-M1</version>
+		</dependency>
         <dependency>
             <groupId>jakarta.validation</groupId>
             <artifactId>jakarta.validation-api</artifactId>
@@ -59,10 +74,10 @@
         <dependency>
             <groupId>org.hibernate.validator</groupId>
             <artifactId>hibernate-validator</artifactId>
-            <version>6.0.17.Final</version>
+            <version>7.0.0.Alpha4</version>
              <exclusions>
                 <exclusion>
-                    <groupId>javax.validation</groupId>
+                    <groupId>jakarta.validation</groupId>
                     <artifactId>validation-api</artifactId>
                 </exclusion>
             </exclusions>
@@ -120,7 +135,7 @@
         <dependency>
             <groupId>jakarta.annotation</groupId>
             <artifactId>jakarta.annotation-api</artifactId>
-            <version>1.3.4</version>
+            <version>2.0.0-RC1</version>
         </dependency>
         <dependency>
             <groupId>jakarta.el</groupId>
@@ -128,15 +143,9 @@
             <version>${jakarta.el.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.hibernate.javax.persistence</groupId>
-            <artifactId>hibernate-jpa-2.0-api</artifactId>
-            <version>1.0.1.Final</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.hibernate.beanvalidation.tck</groupId>
+            <groupId>jakarta.validation</groupId>
             <artifactId>beanvalidation-tck-tests</artifactId>
-            <version>2.0.5</version>
+            <version>3.0.0-M5</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -202,6 +211,11 @@
           <version>2.21.0</version>
           <type>maven-plugin</type>
         </dependency>
+        <dependency>
+	        <groupId>org.jboss.arquillian.container</groupId>
+	        <artifactId>arquillian-glassfish-managed-6</artifactId>
+	        <version>1.0.0-SNAPSHOT</version>
+        </dependency>
     </dependencies>
  
     <build>
@@ -237,8 +251,9 @@
                             <stripVersion>true</stripVersion>
                             <artifactItems>
                                 <artifactItem>
-                                    <groupId>org.hibernate.beanvalidation.tck</groupId>
+                                    <groupId>jakarta.validation</groupId>
                                     <artifactId>beanvalidation-tck-tests</artifactId>
+                                    <classifier>suite</classifier>
                                     <type>xml</type>
                                     <overWrite>false</overWrite>
                                 </artifactItem>
@@ -265,9 +280,8 @@
                             <name>validation.provider</name>
                             <value>${validation.provider}</value>
                         </property>
+                        <arquillian.launch>remote</arquillian.launch>
                     </systemProperties>
-                    <parallel>methods</parallel>
-                    <threadCount>4</threadCount>
                 </configuration>
             </plugin>
             <plugin>
@@ -290,52 +304,66 @@
         </plugins>
     </build>
  
-    <profiles>
+      <profiles>
+        <profile>
+            <id>glassish-remote</id>
+            <dependencies>
+                <dependency>
+                    <groupId>org.jboss.arquillian.container</groupId>
+                    <artifactId>arquillian-glassfish-remote-6</artifactId>
+                    <version>1.0.0-SNAPSHOT</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+            <build>
+                <plugins>
+                    <!-- Run the tests -->
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>2.19.1</version>
+                        <configuration>
+                            <argLine>-Xmx1024m</argLine>
+                            <forkMode>once</forkMode>
+                            <suiteXmlFiles>
+                                <suiteXmlFile>${tck.suite.file}</suiteXmlFile>
+                            </suiteXmlFiles>
+                            <systemPropertyVariables>
+                                <validation.provider>${validation.provider}</validation.provider>
+                                <arquillian.launch>incontainer</arquillian.launch>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
         <profile>
             <id>glassfish-managed</id>
             <activation>
                 <activeByDefault>true</activeByDefault>
             </activation>
-            <properties>
-                <arquillian.protocol>Servlet 3.0</arquillian.protocol>
-            </properties>
             <dependencies>
                 <dependency>
-                    <groupId>junit</groupId>
-                    <artifactId>junit</artifactId>
-                    <version>4.12</version>
-                    <scope>test</scope>
-                </dependency>
- 
-                <dependency>
                     <groupId>org.jboss.arquillian.container</groupId>
-                    <artifactId>arquillian-glassfish-managed-3.1</artifactId>
-                    <version>1.0.2</version>
+                    <artifactId>arquillian-glassfish-managed-6</artifactId>
+                    <version>1.0.0-SNAPSHOT</version>
                     <scope>test</scope>
                 </dependency>
             </dependencies>
- 
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
+                        <version>2.19.1</version>
                         <configuration>
-                            <argLine>-Xmx1024m -Djava.util.logging.manager=org.jboss.logmanager.LogManager -Dvalidation.provider=${validation.provider}</argLine>
+                            <argLine>-Xmx1024m</argLine>
                             <forkMode>once</forkMode>
                             <suiteXmlFiles>
                                 <suiteXmlFile>${tck.suite.file}</suiteXmlFile>
                             </suiteXmlFiles>
-                            <properties>
-                                <property>
-                                    <name>usedefaultlisteners</name>
-                                    <value>false</value>
-                                </property>
-                            </properties>
                             <systemPropertyVariables>
                                 <arquillian.launch>glassfish</arquillian.launch>
-                                <validation.provider>${validation.provider}</validation.provider>
-                                <includeIntegrationTests>true</includeIntegrationTests>
+                                 <validation.provider>${validation.provider}</validation.provider>
+                                 <includeIntegrationTests>true</includeIntegrationTests>
                             </systemPropertyVariables>
                         </configuration>
                     </plugin>

--- a/glassfish-tck-runner/src/test/resources/arquillian.template.xml
+++ b/glassfish-tck-runner/src/test/resources/arquillian.template.xml
@@ -22,7 +22,7 @@
         http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
 
     <!-- Need to set the default protocol and use resource filtering, because of https://issues.jboss.org/browse/ARQ-579 -->
-    <defaultProtocol type="${arquillian.protocol}"/>
+    <defaultProtocol type="Servlet 5.0"/>
 
     <engine>
         <property name="maxTestClassesBeforeRestart">@maxClassesRestart@</property>
@@ -39,7 +39,9 @@
             <property name="adminPassword">@adminPassword@</property>
             <property name="debug">true</property>
             <property name="validation.provider">${validation.provider}</property>
-            <!--<property name="allowConnectingToRunningServer">true</property>-->
+            <!--
+            <property name="allowConnectingToRunningServer">true</property>
+            -->
         </configuration>
     </container>
     

--- a/settings.xml
+++ b/settings.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,6 +17,7 @@
 -->
 
 <settings>
+    <localRepository>${env.TS_HOME}/.m2</localRepository>
 <activeProfiles>
     <activeProfile>default</activeProfile>
   </activeProfiles>
@@ -25,47 +26,24 @@
 <id>default</id>
 <repositories>
     <repository>
-      <id>jboss-public-repository-group</id>
-      <name>JBoss Public Repository Group</name>
-      <url>http://repository.jboss.org/nexus/content/groups/public/</url>
+      <id>central</id>
+      <name>Central Repository</name>
+      <url>https://repo.maven.apache.org/maven2</url>
       <layout>default</layout>
-      <releases>
-        <enabled>true</enabled>
-        <updatePolicy>never</updatePolicy>
-      </releases>
       <snapshots>
         <enabled>true</enabled>
-        <updatePolicy>never</updatePolicy>
       </snapshots>
     </repository>
-     <repository>
-      <id>oss-public-repository-group</id>
-      <name>OSS Sonatype Public Repository Group</name>
-      <url>https://oss.sonatype.org/content/repositories/staging</url>
+    <repository>
+      <id>jboss</id>
+      <name>Central Repository</name>
+      <url>https://repository.jboss.org/nexus/content/repositories/releases/</url>
       <layout>default</layout>
-      <releases>
-        <enabled>true</enabled>
-        <updatePolicy>always</updatePolicy>
-      </releases>
       <snapshots>
         <enabled>true</enabled>
-        <updatePolicy>always</updatePolicy>
       </snapshots>
     </repository>
-  </repositories>
-  <pluginRepositories>
-    <pluginRepository>
-      <id>jboss-public-repository-group</id>
-      <name>JBoss Public Repository Group</name>
-      <url>http://repository.jboss.org/nexus/content/groups/public/</url>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </pluginRepository>
-  </pluginRepositories>
+</repositories>
 </profile>
 </profiles>
 </settings>

--- a/validation-api-java8.sig
+++ b/validation-api-java8.sig
@@ -135,7 +135,7 @@ CLSS public abstract interface !annotation java.lang.annotation.Target
 intf java.lang.annotation.Annotation
 meth public abstract java.lang.annotation.ElementType[] value()
 
-CLSS public abstract interface javax.validation.BootstrapConfiguration
+CLSS public abstract interface jakarta.validation.BootstrapConfiguration
 meth public abstract boolean isExecutableValidationEnabled()
 meth public abstract java.lang.String getClockProviderClassName()
 meth public abstract java.lang.String getConstraintValidatorFactoryClassName()
@@ -146,72 +146,72 @@ meth public abstract java.lang.String getTraversableResolverClassName()
 meth public abstract java.util.Map<java.lang.String,java.lang.String> getProperties()
 meth public abstract java.util.Set<java.lang.String> getConstraintMappingResourcePaths()
 meth public abstract java.util.Set<java.lang.String> getValueExtractorClassNames()
-meth public abstract java.util.Set<javax.validation.executable.ExecutableType> getDefaultValidatedExecutableTypes()
+meth public abstract java.util.Set<jakarta.validation.executable.ExecutableType> getDefaultValidatedExecutableTypes()
 
-CLSS public abstract interface javax.validation.ClockProvider
+CLSS public abstract interface jakarta.validation.ClockProvider
 meth public abstract java.time.Clock getClock()
 
-CLSS public abstract interface javax.validation.Configuration<%0 extends javax.validation.Configuration<{javax.validation.Configuration%0}>>
-meth public abstract javax.validation.BootstrapConfiguration getBootstrapConfiguration()
-meth public abstract javax.validation.ClockProvider getDefaultClockProvider()
-meth public abstract javax.validation.ConstraintValidatorFactory getDefaultConstraintValidatorFactory()
-meth public abstract javax.validation.MessageInterpolator getDefaultMessageInterpolator()
-meth public abstract javax.validation.ParameterNameProvider getDefaultParameterNameProvider()
-meth public abstract javax.validation.TraversableResolver getDefaultTraversableResolver()
-meth public abstract javax.validation.ValidatorFactory buildValidatorFactory()
-meth public abstract {javax.validation.Configuration%0} addMapping(java.io.InputStream)
-meth public abstract {javax.validation.Configuration%0} addProperty(java.lang.String,java.lang.String)
-meth public abstract {javax.validation.Configuration%0} addValueExtractor(javax.validation.valueextraction.ValueExtractor<?>)
-meth public abstract {javax.validation.Configuration%0} clockProvider(javax.validation.ClockProvider)
-meth public abstract {javax.validation.Configuration%0} constraintValidatorFactory(javax.validation.ConstraintValidatorFactory)
-meth public abstract {javax.validation.Configuration%0} ignoreXmlConfiguration()
-meth public abstract {javax.validation.Configuration%0} messageInterpolator(javax.validation.MessageInterpolator)
-meth public abstract {javax.validation.Configuration%0} parameterNameProvider(javax.validation.ParameterNameProvider)
-meth public abstract {javax.validation.Configuration%0} traversableResolver(javax.validation.TraversableResolver)
+CLSS public abstract interface jakarta.validation.Configuration<%0 extends jakarta.validation.Configuration<{jakarta.validation.Configuration%0}>>
+meth public abstract jakarta.validation.BootstrapConfiguration getBootstrapConfiguration()
+meth public abstract jakarta.validation.ClockProvider getDefaultClockProvider()
+meth public abstract jakarta.validation.ConstraintValidatorFactory getDefaultConstraintValidatorFactory()
+meth public abstract jakarta.validation.MessageInterpolator getDefaultMessageInterpolator()
+meth public abstract jakarta.validation.ParameterNameProvider getDefaultParameterNameProvider()
+meth public abstract jakarta.validation.TraversableResolver getDefaultTraversableResolver()
+meth public abstract jakarta.validation.ValidatorFactory buildValidatorFactory()
+meth public abstract {jakarta.validation.Configuration%0} addMapping(java.io.InputStream)
+meth public abstract {jakarta.validation.Configuration%0} addProperty(java.lang.String,java.lang.String)
+meth public abstract {jakarta.validation.Configuration%0} addValueExtractor(jakarta.validation.valueextraction.ValueExtractor<?>)
+meth public abstract {jakarta.validation.Configuration%0} clockProvider(jakarta.validation.ClockProvider)
+meth public abstract {jakarta.validation.Configuration%0} constraintValidatorFactory(jakarta.validation.ConstraintValidatorFactory)
+meth public abstract {jakarta.validation.Configuration%0} ignoreXmlConfiguration()
+meth public abstract {jakarta.validation.Configuration%0} messageInterpolator(jakarta.validation.MessageInterpolator)
+meth public abstract {jakarta.validation.Configuration%0} parameterNameProvider(jakarta.validation.ParameterNameProvider)
+meth public abstract {jakarta.validation.Configuration%0} traversableResolver(jakarta.validation.TraversableResolver)
 
-CLSS public abstract interface !annotation javax.validation.Constraint
+CLSS public abstract interface !annotation jakarta.validation.Constraint
  anno 0 java.lang.annotation.Documented()
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[ANNOTATION_TYPE])
 intf java.lang.annotation.Annotation
-meth public abstract java.lang.Class<? extends javax.validation.ConstraintValidator<?,?>>[] validatedBy()
+meth public abstract java.lang.Class<? extends jakarta.validation.ConstraintValidator<?,?>>[] validatedBy()
 
-CLSS public javax.validation.ConstraintDeclarationException
+CLSS public jakarta.validation.ConstraintDeclarationException
 cons public init()
 cons public init(java.lang.String)
 cons public init(java.lang.String,java.lang.Throwable)
 cons public init(java.lang.Throwable)
-supr javax.validation.ValidationException
+supr jakarta.validation.ValidationException
 
-CLSS public javax.validation.ConstraintDefinitionException
+CLSS public jakarta.validation.ConstraintDefinitionException
 cons public init()
 cons public init(java.lang.String)
 cons public init(java.lang.String,java.lang.Throwable)
 cons public init(java.lang.Throwable)
-supr javax.validation.ValidationException
+supr jakarta.validation.ValidationException
 
-CLSS public final !enum javax.validation.ConstraintTarget
-fld public final static javax.validation.ConstraintTarget IMPLICIT
-fld public final static javax.validation.ConstraintTarget PARAMETERS
-fld public final static javax.validation.ConstraintTarget RETURN_VALUE
-meth public static javax.validation.ConstraintTarget valueOf(java.lang.String)
-meth public static javax.validation.ConstraintTarget[] values()
-supr java.lang.Enum<javax.validation.ConstraintTarget>
+CLSS public final !enum jakarta.validation.ConstraintTarget
+fld public final static jakarta.validation.ConstraintTarget IMPLICIT
+fld public final static jakarta.validation.ConstraintTarget PARAMETERS
+fld public final static jakarta.validation.ConstraintTarget RETURN_VALUE
+meth public static jakarta.validation.ConstraintTarget valueOf(java.lang.String)
+meth public static jakarta.validation.ConstraintTarget[] values()
+supr java.lang.Enum<jakarta.validation.ConstraintTarget>
 
-CLSS public abstract interface javax.validation.ConstraintValidator<%0 extends java.lang.annotation.Annotation, %1 extends java.lang.Object>
-meth public abstract boolean isValid({javax.validation.ConstraintValidator%1},javax.validation.ConstraintValidatorContext)
-meth public void initialize({javax.validation.ConstraintValidator%0})
+CLSS public abstract interface jakarta.validation.ConstraintValidator<%0 extends java.lang.annotation.Annotation, %1 extends java.lang.Object>
+meth public abstract boolean isValid({jakarta.validation.ConstraintValidator%1},jakarta.validation.ConstraintValidatorContext)
+meth public void initialize({jakarta.validation.ConstraintValidator%0})
 
-CLSS public abstract interface javax.validation.ConstraintValidatorContext
+CLSS public abstract interface jakarta.validation.ConstraintValidatorContext
 innr public abstract interface static ConstraintViolationBuilder
 meth public abstract <%0 extends java.lang.Object> {%%0} unwrap(java.lang.Class<{%%0}>)
 meth public abstract java.lang.String getDefaultConstraintMessageTemplate()
-meth public abstract javax.validation.ClockProvider getClockProvider()
-meth public abstract javax.validation.ConstraintValidatorContext$ConstraintViolationBuilder buildConstraintViolationWithTemplate(java.lang.String)
+meth public abstract jakarta.validation.ClockProvider getClockProvider()
+meth public abstract jakarta.validation.ConstraintValidatorContext$ConstraintViolationBuilder buildConstraintViolationWithTemplate(java.lang.String)
 meth public abstract void disableDefaultConstraintViolation()
 
-CLSS public abstract interface static javax.validation.ConstraintValidatorContext$ConstraintViolationBuilder
- outer javax.validation.ConstraintValidatorContext
+CLSS public abstract interface static jakarta.validation.ConstraintValidatorContext$ConstraintViolationBuilder
+ outer jakarta.validation.ConstraintValidatorContext
 innr public abstract interface static ContainerElementNodeBuilderCustomizableContext
 innr public abstract interface static ContainerElementNodeBuilderDefinedContext
 innr public abstract interface static ContainerElementNodeContextBuilder
@@ -221,153 +221,153 @@ innr public abstract interface static LeafNodeContextBuilder
 innr public abstract interface static NodeBuilderCustomizableContext
 innr public abstract interface static NodeBuilderDefinedContext
 innr public abstract interface static NodeContextBuilder
-meth public abstract javax.validation.ConstraintValidatorContext addConstraintViolation()
-meth public abstract javax.validation.ConstraintValidatorContext$ConstraintViolationBuilder$ContainerElementNodeBuilderCustomizableContext addContainerElementNode(java.lang.String,java.lang.Class<?>,java.lang.Integer)
-meth public abstract javax.validation.ConstraintValidatorContext$ConstraintViolationBuilder$LeafNodeBuilderCustomizableContext addBeanNode()
-meth public abstract javax.validation.ConstraintValidatorContext$ConstraintViolationBuilder$NodeBuilderCustomizableContext addPropertyNode(java.lang.String)
-meth public abstract javax.validation.ConstraintValidatorContext$ConstraintViolationBuilder$NodeBuilderDefinedContext addNode(java.lang.String)
-meth public abstract javax.validation.ConstraintValidatorContext$ConstraintViolationBuilder$NodeBuilderDefinedContext addParameterNode(int)
+meth public abstract jakarta.validation.ConstraintValidatorContext addConstraintViolation()
+meth public abstract jakarta.validation.ConstraintValidatorContext$ConstraintViolationBuilder$ContainerElementNodeBuilderCustomizableContext addContainerElementNode(java.lang.String,java.lang.Class<?>,java.lang.Integer)
+meth public abstract jakarta.validation.ConstraintValidatorContext$ConstraintViolationBuilder$LeafNodeBuilderCustomizableContext addBeanNode()
+meth public abstract jakarta.validation.ConstraintValidatorContext$ConstraintViolationBuilder$NodeBuilderCustomizableContext addPropertyNode(java.lang.String)
+meth public abstract jakarta.validation.ConstraintValidatorContext$ConstraintViolationBuilder$NodeBuilderDefinedContext addNode(java.lang.String)
+meth public abstract jakarta.validation.ConstraintValidatorContext$ConstraintViolationBuilder$NodeBuilderDefinedContext addParameterNode(int)
 
-CLSS public abstract interface static javax.validation.ConstraintValidatorContext$ConstraintViolationBuilder$ContainerElementNodeBuilderCustomizableContext
- outer javax.validation.ConstraintValidatorContext$ConstraintViolationBuilder
-meth public abstract javax.validation.ConstraintValidatorContext addConstraintViolation()
-meth public abstract javax.validation.ConstraintValidatorContext$ConstraintViolationBuilder$ContainerElementNodeBuilderCustomizableContext addContainerElementNode(java.lang.String,java.lang.Class<?>,java.lang.Integer)
-meth public abstract javax.validation.ConstraintValidatorContext$ConstraintViolationBuilder$ContainerElementNodeContextBuilder inIterable()
-meth public abstract javax.validation.ConstraintValidatorContext$ConstraintViolationBuilder$LeafNodeBuilderCustomizableContext addBeanNode()
-meth public abstract javax.validation.ConstraintValidatorContext$ConstraintViolationBuilder$NodeBuilderCustomizableContext addPropertyNode(java.lang.String)
+CLSS public abstract interface static jakarta.validation.ConstraintValidatorContext$ConstraintViolationBuilder$ContainerElementNodeBuilderCustomizableContext
+ outer jakarta.validation.ConstraintValidatorContext$ConstraintViolationBuilder
+meth public abstract jakarta.validation.ConstraintValidatorContext addConstraintViolation()
+meth public abstract jakarta.validation.ConstraintValidatorContext$ConstraintViolationBuilder$ContainerElementNodeBuilderCustomizableContext addContainerElementNode(java.lang.String,java.lang.Class<?>,java.lang.Integer)
+meth public abstract jakarta.validation.ConstraintValidatorContext$ConstraintViolationBuilder$ContainerElementNodeContextBuilder inIterable()
+meth public abstract jakarta.validation.ConstraintValidatorContext$ConstraintViolationBuilder$LeafNodeBuilderCustomizableContext addBeanNode()
+meth public abstract jakarta.validation.ConstraintValidatorContext$ConstraintViolationBuilder$NodeBuilderCustomizableContext addPropertyNode(java.lang.String)
 
-CLSS public abstract interface static javax.validation.ConstraintValidatorContext$ConstraintViolationBuilder$ContainerElementNodeBuilderDefinedContext
- outer javax.validation.ConstraintValidatorContext$ConstraintViolationBuilder
-meth public abstract javax.validation.ConstraintValidatorContext addConstraintViolation()
-meth public abstract javax.validation.ConstraintValidatorContext$ConstraintViolationBuilder$ContainerElementNodeBuilderCustomizableContext addContainerElementNode(java.lang.String,java.lang.Class<?>,java.lang.Integer)
-meth public abstract javax.validation.ConstraintValidatorContext$ConstraintViolationBuilder$LeafNodeBuilderCustomizableContext addBeanNode()
-meth public abstract javax.validation.ConstraintValidatorContext$ConstraintViolationBuilder$NodeBuilderCustomizableContext addPropertyNode(java.lang.String)
+CLSS public abstract interface static jakarta.validation.ConstraintValidatorContext$ConstraintViolationBuilder$ContainerElementNodeBuilderDefinedContext
+ outer jakarta.validation.ConstraintValidatorContext$ConstraintViolationBuilder
+meth public abstract jakarta.validation.ConstraintValidatorContext addConstraintViolation()
+meth public abstract jakarta.validation.ConstraintValidatorContext$ConstraintViolationBuilder$ContainerElementNodeBuilderCustomizableContext addContainerElementNode(java.lang.String,java.lang.Class<?>,java.lang.Integer)
+meth public abstract jakarta.validation.ConstraintValidatorContext$ConstraintViolationBuilder$LeafNodeBuilderCustomizableContext addBeanNode()
+meth public abstract jakarta.validation.ConstraintValidatorContext$ConstraintViolationBuilder$NodeBuilderCustomizableContext addPropertyNode(java.lang.String)
 
-CLSS public abstract interface static javax.validation.ConstraintValidatorContext$ConstraintViolationBuilder$ContainerElementNodeContextBuilder
- outer javax.validation.ConstraintValidatorContext$ConstraintViolationBuilder
-meth public abstract javax.validation.ConstraintValidatorContext addConstraintViolation()
-meth public abstract javax.validation.ConstraintValidatorContext$ConstraintViolationBuilder$ContainerElementNodeBuilderCustomizableContext addContainerElementNode(java.lang.String,java.lang.Class<?>,java.lang.Integer)
-meth public abstract javax.validation.ConstraintValidatorContext$ConstraintViolationBuilder$ContainerElementNodeBuilderDefinedContext atIndex(java.lang.Integer)
-meth public abstract javax.validation.ConstraintValidatorContext$ConstraintViolationBuilder$ContainerElementNodeBuilderDefinedContext atKey(java.lang.Object)
-meth public abstract javax.validation.ConstraintValidatorContext$ConstraintViolationBuilder$LeafNodeBuilderCustomizableContext addBeanNode()
-meth public abstract javax.validation.ConstraintValidatorContext$ConstraintViolationBuilder$NodeBuilderCustomizableContext addPropertyNode(java.lang.String)
+CLSS public abstract interface static jakarta.validation.ConstraintValidatorContext$ConstraintViolationBuilder$ContainerElementNodeContextBuilder
+ outer jakarta.validation.ConstraintValidatorContext$ConstraintViolationBuilder
+meth public abstract jakarta.validation.ConstraintValidatorContext addConstraintViolation()
+meth public abstract jakarta.validation.ConstraintValidatorContext$ConstraintViolationBuilder$ContainerElementNodeBuilderCustomizableContext addContainerElementNode(java.lang.String,java.lang.Class<?>,java.lang.Integer)
+meth public abstract jakarta.validation.ConstraintValidatorContext$ConstraintViolationBuilder$ContainerElementNodeBuilderDefinedContext atIndex(java.lang.Integer)
+meth public abstract jakarta.validation.ConstraintValidatorContext$ConstraintViolationBuilder$ContainerElementNodeBuilderDefinedContext atKey(java.lang.Object)
+meth public abstract jakarta.validation.ConstraintValidatorContext$ConstraintViolationBuilder$LeafNodeBuilderCustomizableContext addBeanNode()
+meth public abstract jakarta.validation.ConstraintValidatorContext$ConstraintViolationBuilder$NodeBuilderCustomizableContext addPropertyNode(java.lang.String)
 
-CLSS public abstract interface static javax.validation.ConstraintValidatorContext$ConstraintViolationBuilder$LeafNodeBuilderCustomizableContext
- outer javax.validation.ConstraintValidatorContext$ConstraintViolationBuilder
-meth public abstract javax.validation.ConstraintValidatorContext addConstraintViolation()
-meth public abstract javax.validation.ConstraintValidatorContext$ConstraintViolationBuilder$LeafNodeBuilderCustomizableContext inContainer(java.lang.Class<?>,java.lang.Integer)
-meth public abstract javax.validation.ConstraintValidatorContext$ConstraintViolationBuilder$LeafNodeContextBuilder inIterable()
+CLSS public abstract interface static jakarta.validation.ConstraintValidatorContext$ConstraintViolationBuilder$LeafNodeBuilderCustomizableContext
+ outer jakarta.validation.ConstraintValidatorContext$ConstraintViolationBuilder
+meth public abstract jakarta.validation.ConstraintValidatorContext addConstraintViolation()
+meth public abstract jakarta.validation.ConstraintValidatorContext$ConstraintViolationBuilder$LeafNodeBuilderCustomizableContext inContainer(java.lang.Class<?>,java.lang.Integer)
+meth public abstract jakarta.validation.ConstraintValidatorContext$ConstraintViolationBuilder$LeafNodeContextBuilder inIterable()
 
-CLSS public abstract interface static javax.validation.ConstraintValidatorContext$ConstraintViolationBuilder$LeafNodeBuilderDefinedContext
- outer javax.validation.ConstraintValidatorContext$ConstraintViolationBuilder
-meth public abstract javax.validation.ConstraintValidatorContext addConstraintViolation()
+CLSS public abstract interface static jakarta.validation.ConstraintValidatorContext$ConstraintViolationBuilder$LeafNodeBuilderDefinedContext
+ outer jakarta.validation.ConstraintValidatorContext$ConstraintViolationBuilder
+meth public abstract jakarta.validation.ConstraintValidatorContext addConstraintViolation()
 
-CLSS public abstract interface static javax.validation.ConstraintValidatorContext$ConstraintViolationBuilder$LeafNodeContextBuilder
- outer javax.validation.ConstraintValidatorContext$ConstraintViolationBuilder
-meth public abstract javax.validation.ConstraintValidatorContext addConstraintViolation()
-meth public abstract javax.validation.ConstraintValidatorContext$ConstraintViolationBuilder$LeafNodeBuilderDefinedContext atIndex(java.lang.Integer)
-meth public abstract javax.validation.ConstraintValidatorContext$ConstraintViolationBuilder$LeafNodeBuilderDefinedContext atKey(java.lang.Object)
+CLSS public abstract interface static jakarta.validation.ConstraintValidatorContext$ConstraintViolationBuilder$LeafNodeContextBuilder
+ outer jakarta.validation.ConstraintValidatorContext$ConstraintViolationBuilder
+meth public abstract jakarta.validation.ConstraintValidatorContext addConstraintViolation()
+meth public abstract jakarta.validation.ConstraintValidatorContext$ConstraintViolationBuilder$LeafNodeBuilderDefinedContext atIndex(java.lang.Integer)
+meth public abstract jakarta.validation.ConstraintValidatorContext$ConstraintViolationBuilder$LeafNodeBuilderDefinedContext atKey(java.lang.Object)
 
-CLSS public abstract interface static javax.validation.ConstraintValidatorContext$ConstraintViolationBuilder$NodeBuilderCustomizableContext
- outer javax.validation.ConstraintValidatorContext$ConstraintViolationBuilder
-meth public abstract javax.validation.ConstraintValidatorContext addConstraintViolation()
-meth public abstract javax.validation.ConstraintValidatorContext$ConstraintViolationBuilder$ContainerElementNodeBuilderCustomizableContext addContainerElementNode(java.lang.String,java.lang.Class<?>,java.lang.Integer)
-meth public abstract javax.validation.ConstraintValidatorContext$ConstraintViolationBuilder$LeafNodeBuilderCustomizableContext addBeanNode()
-meth public abstract javax.validation.ConstraintValidatorContext$ConstraintViolationBuilder$NodeBuilderCustomizableContext addNode(java.lang.String)
-meth public abstract javax.validation.ConstraintValidatorContext$ConstraintViolationBuilder$NodeBuilderCustomizableContext addPropertyNode(java.lang.String)
-meth public abstract javax.validation.ConstraintValidatorContext$ConstraintViolationBuilder$NodeBuilderCustomizableContext inContainer(java.lang.Class<?>,java.lang.Integer)
-meth public abstract javax.validation.ConstraintValidatorContext$ConstraintViolationBuilder$NodeContextBuilder inIterable()
+CLSS public abstract interface static jakarta.validation.ConstraintValidatorContext$ConstraintViolationBuilder$NodeBuilderCustomizableContext
+ outer jakarta.validation.ConstraintValidatorContext$ConstraintViolationBuilder
+meth public abstract jakarta.validation.ConstraintValidatorContext addConstraintViolation()
+meth public abstract jakarta.validation.ConstraintValidatorContext$ConstraintViolationBuilder$ContainerElementNodeBuilderCustomizableContext addContainerElementNode(java.lang.String,java.lang.Class<?>,java.lang.Integer)
+meth public abstract jakarta.validation.ConstraintValidatorContext$ConstraintViolationBuilder$LeafNodeBuilderCustomizableContext addBeanNode()
+meth public abstract jakarta.validation.ConstraintValidatorContext$ConstraintViolationBuilder$NodeBuilderCustomizableContext addNode(java.lang.String)
+meth public abstract jakarta.validation.ConstraintValidatorContext$ConstraintViolationBuilder$NodeBuilderCustomizableContext addPropertyNode(java.lang.String)
+meth public abstract jakarta.validation.ConstraintValidatorContext$ConstraintViolationBuilder$NodeBuilderCustomizableContext inContainer(java.lang.Class<?>,java.lang.Integer)
+meth public abstract jakarta.validation.ConstraintValidatorContext$ConstraintViolationBuilder$NodeContextBuilder inIterable()
 
-CLSS public abstract interface static javax.validation.ConstraintValidatorContext$ConstraintViolationBuilder$NodeBuilderDefinedContext
- outer javax.validation.ConstraintValidatorContext$ConstraintViolationBuilder
-meth public abstract javax.validation.ConstraintValidatorContext addConstraintViolation()
-meth public abstract javax.validation.ConstraintValidatorContext$ConstraintViolationBuilder$ContainerElementNodeBuilderCustomizableContext addContainerElementNode(java.lang.String,java.lang.Class<?>,java.lang.Integer)
-meth public abstract javax.validation.ConstraintValidatorContext$ConstraintViolationBuilder$LeafNodeBuilderCustomizableContext addBeanNode()
-meth public abstract javax.validation.ConstraintValidatorContext$ConstraintViolationBuilder$NodeBuilderCustomizableContext addNode(java.lang.String)
-meth public abstract javax.validation.ConstraintValidatorContext$ConstraintViolationBuilder$NodeBuilderCustomizableContext addPropertyNode(java.lang.String)
+CLSS public abstract interface static jakarta.validation.ConstraintValidatorContext$ConstraintViolationBuilder$NodeBuilderDefinedContext
+ outer jakarta.validation.ConstraintValidatorContext$ConstraintViolationBuilder
+meth public abstract jakarta.validation.ConstraintValidatorContext addConstraintViolation()
+meth public abstract jakarta.validation.ConstraintValidatorContext$ConstraintViolationBuilder$ContainerElementNodeBuilderCustomizableContext addContainerElementNode(java.lang.String,java.lang.Class<?>,java.lang.Integer)
+meth public abstract jakarta.validation.ConstraintValidatorContext$ConstraintViolationBuilder$LeafNodeBuilderCustomizableContext addBeanNode()
+meth public abstract jakarta.validation.ConstraintValidatorContext$ConstraintViolationBuilder$NodeBuilderCustomizableContext addNode(java.lang.String)
+meth public abstract jakarta.validation.ConstraintValidatorContext$ConstraintViolationBuilder$NodeBuilderCustomizableContext addPropertyNode(java.lang.String)
 
-CLSS public abstract interface static javax.validation.ConstraintValidatorContext$ConstraintViolationBuilder$NodeContextBuilder
- outer javax.validation.ConstraintValidatorContext$ConstraintViolationBuilder
-meth public abstract javax.validation.ConstraintValidatorContext addConstraintViolation()
-meth public abstract javax.validation.ConstraintValidatorContext$ConstraintViolationBuilder$ContainerElementNodeBuilderCustomizableContext addContainerElementNode(java.lang.String,java.lang.Class<?>,java.lang.Integer)
-meth public abstract javax.validation.ConstraintValidatorContext$ConstraintViolationBuilder$LeafNodeBuilderCustomizableContext addBeanNode()
-meth public abstract javax.validation.ConstraintValidatorContext$ConstraintViolationBuilder$NodeBuilderCustomizableContext addNode(java.lang.String)
-meth public abstract javax.validation.ConstraintValidatorContext$ConstraintViolationBuilder$NodeBuilderCustomizableContext addPropertyNode(java.lang.String)
-meth public abstract javax.validation.ConstraintValidatorContext$ConstraintViolationBuilder$NodeBuilderDefinedContext atIndex(java.lang.Integer)
-meth public abstract javax.validation.ConstraintValidatorContext$ConstraintViolationBuilder$NodeBuilderDefinedContext atKey(java.lang.Object)
+CLSS public abstract interface static jakarta.validation.ConstraintValidatorContext$ConstraintViolationBuilder$NodeContextBuilder
+ outer jakarta.validation.ConstraintValidatorContext$ConstraintViolationBuilder
+meth public abstract jakarta.validation.ConstraintValidatorContext addConstraintViolation()
+meth public abstract jakarta.validation.ConstraintValidatorContext$ConstraintViolationBuilder$ContainerElementNodeBuilderCustomizableContext addContainerElementNode(java.lang.String,java.lang.Class<?>,java.lang.Integer)
+meth public abstract jakarta.validation.ConstraintValidatorContext$ConstraintViolationBuilder$LeafNodeBuilderCustomizableContext addBeanNode()
+meth public abstract jakarta.validation.ConstraintValidatorContext$ConstraintViolationBuilder$NodeBuilderCustomizableContext addNode(java.lang.String)
+meth public abstract jakarta.validation.ConstraintValidatorContext$ConstraintViolationBuilder$NodeBuilderCustomizableContext addPropertyNode(java.lang.String)
+meth public abstract jakarta.validation.ConstraintValidatorContext$ConstraintViolationBuilder$NodeBuilderDefinedContext atIndex(java.lang.Integer)
+meth public abstract jakarta.validation.ConstraintValidatorContext$ConstraintViolationBuilder$NodeBuilderDefinedContext atKey(java.lang.Object)
 
-CLSS public abstract interface javax.validation.ConstraintValidatorFactory
-meth public abstract <%0 extends javax.validation.ConstraintValidator<?,?>> {%%0} getInstance(java.lang.Class<{%%0}>)
-meth public abstract void releaseInstance(javax.validation.ConstraintValidator<?,?>)
+CLSS public abstract interface jakarta.validation.ConstraintValidatorFactory
+meth public abstract <%0 extends jakarta.validation.ConstraintValidator<?,?>> {%%0} getInstance(java.lang.Class<{%%0}>)
+meth public abstract void releaseInstance(jakarta.validation.ConstraintValidator<?,?>)
 
-CLSS public abstract interface javax.validation.ConstraintViolation<%0 extends java.lang.Object>
+CLSS public abstract interface jakarta.validation.ConstraintViolation<%0 extends java.lang.Object>
 meth public abstract <%0 extends java.lang.Object> {%%0} unwrap(java.lang.Class<{%%0}>)
-meth public abstract java.lang.Class<{javax.validation.ConstraintViolation%0}> getRootBeanClass()
+meth public abstract java.lang.Class<{jakarta.validation.ConstraintViolation%0}> getRootBeanClass()
 meth public abstract java.lang.Object getExecutableReturnValue()
 meth public abstract java.lang.Object getInvalidValue()
 meth public abstract java.lang.Object getLeafBean()
 meth public abstract java.lang.Object[] getExecutableParameters()
 meth public abstract java.lang.String getMessage()
 meth public abstract java.lang.String getMessageTemplate()
-meth public abstract javax.validation.Path getPropertyPath()
-meth public abstract javax.validation.metadata.ConstraintDescriptor<?> getConstraintDescriptor()
-meth public abstract {javax.validation.ConstraintViolation%0} getRootBean()
+meth public abstract jakarta.validation.Path getPropertyPath()
+meth public abstract jakarta.validation.metadata.ConstraintDescriptor<?> getConstraintDescriptor()
+meth public abstract {jakarta.validation.ConstraintViolation%0} getRootBean()
 
-CLSS public javax.validation.ConstraintViolationException
-cons public init(java.lang.String,java.util.Set<? extends javax.validation.ConstraintViolation<?>>)
-cons public init(java.util.Set<? extends javax.validation.ConstraintViolation<?>>)
-meth public java.util.Set<javax.validation.ConstraintViolation<?>> getConstraintViolations()
-supr javax.validation.ValidationException
+CLSS public jakarta.validation.ConstraintViolationException
+cons public init(java.lang.String,java.util.Set<? extends jakarta.validation.ConstraintViolation<?>>)
+cons public init(java.util.Set<? extends jakarta.validation.ConstraintViolation<?>>)
+meth public java.util.Set<jakarta.validation.ConstraintViolation<?>> getConstraintViolations()
+supr jakarta.validation.ValidationException
 hfds constraintViolations
 
-CLSS public final !enum javax.validation.ElementKind
-fld public final static javax.validation.ElementKind BEAN
-fld public final static javax.validation.ElementKind CONSTRUCTOR
-fld public final static javax.validation.ElementKind CONTAINER_ELEMENT
-fld public final static javax.validation.ElementKind CROSS_PARAMETER
-fld public final static javax.validation.ElementKind METHOD
-fld public final static javax.validation.ElementKind PARAMETER
-fld public final static javax.validation.ElementKind PROPERTY
-fld public final static javax.validation.ElementKind RETURN_VALUE
-meth public static javax.validation.ElementKind valueOf(java.lang.String)
-meth public static javax.validation.ElementKind[] values()
-supr java.lang.Enum<javax.validation.ElementKind>
+CLSS public final !enum jakarta.validation.ElementKind
+fld public final static jakarta.validation.ElementKind BEAN
+fld public final static jakarta.validation.ElementKind CONSTRUCTOR
+fld public final static jakarta.validation.ElementKind CONTAINER_ELEMENT
+fld public final static jakarta.validation.ElementKind CROSS_PARAMETER
+fld public final static jakarta.validation.ElementKind METHOD
+fld public final static jakarta.validation.ElementKind PARAMETER
+fld public final static jakarta.validation.ElementKind PROPERTY
+fld public final static jakarta.validation.ElementKind RETURN_VALUE
+meth public static jakarta.validation.ElementKind valueOf(java.lang.String)
+meth public static jakarta.validation.ElementKind[] values()
+supr java.lang.Enum<jakarta.validation.ElementKind>
 
-CLSS public javax.validation.GroupDefinitionException
+CLSS public jakarta.validation.GroupDefinitionException
 cons public init()
 cons public init(java.lang.String)
 cons public init(java.lang.String,java.lang.Throwable)
 cons public init(java.lang.Throwable)
-supr javax.validation.ValidationException
+supr jakarta.validation.ValidationException
 
-CLSS public abstract interface !annotation javax.validation.GroupSequence
+CLSS public abstract interface !annotation jakarta.validation.GroupSequence
  anno 0 java.lang.annotation.Documented()
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[TYPE])
 intf java.lang.annotation.Annotation
 meth public abstract java.lang.Class<?>[] value()
 
-CLSS public abstract interface javax.validation.MessageInterpolator
+CLSS public abstract interface jakarta.validation.MessageInterpolator
 innr public abstract interface static Context
-meth public abstract java.lang.String interpolate(java.lang.String,javax.validation.MessageInterpolator$Context)
-meth public abstract java.lang.String interpolate(java.lang.String,javax.validation.MessageInterpolator$Context,java.util.Locale)
+meth public abstract java.lang.String interpolate(java.lang.String,jakarta.validation.MessageInterpolator$Context)
+meth public abstract java.lang.String interpolate(java.lang.String,jakarta.validation.MessageInterpolator$Context,java.util.Locale)
 
-CLSS public abstract interface static javax.validation.MessageInterpolator$Context
- outer javax.validation.MessageInterpolator
+CLSS public abstract interface static jakarta.validation.MessageInterpolator$Context
+ outer jakarta.validation.MessageInterpolator
 meth public abstract <%0 extends java.lang.Object> {%%0} unwrap(java.lang.Class<{%%0}>)
 meth public abstract java.lang.Object getValidatedValue()
-meth public abstract javax.validation.metadata.ConstraintDescriptor<?> getConstraintDescriptor()
+meth public abstract jakarta.validation.metadata.ConstraintDescriptor<?> getConstraintDescriptor()
 
-CLSS public javax.validation.NoProviderFoundException
+CLSS public jakarta.validation.NoProviderFoundException
 cons public init()
 cons public init(java.lang.String)
 cons public init(java.lang.String,java.lang.Throwable)
 cons public init(java.lang.Throwable)
-supr javax.validation.ValidationException
+supr jakarta.validation.ValidationException
 
-CLSS public abstract interface !annotation javax.validation.OverridesAttribute
+CLSS public abstract interface !annotation jakarta.validation.OverridesAttribute
  anno 0 java.lang.annotation.Documented()
- anno 0 java.lang.annotation.Repeatable(java.lang.Class<? extends java.lang.annotation.Annotation> value=class javax.validation.OverridesAttribute$List)
+ anno 0 java.lang.annotation.Repeatable(java.lang.Class<? extends java.lang.annotation.Annotation> value=class jakarta.validation.OverridesAttribute$List)
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[METHOD])
 innr public abstract interface static !annotation List
@@ -376,19 +376,19 @@ meth public abstract !hasdefault int constraintIndex()
 meth public abstract !hasdefault java.lang.String name()
 meth public abstract java.lang.Class<? extends java.lang.annotation.Annotation> constraint()
 
-CLSS public abstract interface static !annotation javax.validation.OverridesAttribute$List
- outer javax.validation.OverridesAttribute
+CLSS public abstract interface static !annotation jakarta.validation.OverridesAttribute$List
+ outer jakarta.validation.OverridesAttribute
  anno 0 java.lang.annotation.Documented()
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[METHOD])
 intf java.lang.annotation.Annotation
-meth public abstract javax.validation.OverridesAttribute[] value()
+meth public abstract jakarta.validation.OverridesAttribute[] value()
 
-CLSS public abstract interface javax.validation.ParameterNameProvider
+CLSS public abstract interface jakarta.validation.ParameterNameProvider
 meth public abstract java.util.List<java.lang.String> getParameterNames(java.lang.reflect.Constructor<?>)
 meth public abstract java.util.List<java.lang.String> getParameterNames(java.lang.reflect.Method)
 
-CLSS public abstract interface javax.validation.Path
+CLSS public abstract interface jakarta.validation.Path
 innr public abstract interface static BeanNode
 innr public abstract interface static ConstructorNode
 innr public abstract interface static ContainerElementNode
@@ -398,651 +398,651 @@ innr public abstract interface static Node
 innr public abstract interface static ParameterNode
 innr public abstract interface static PropertyNode
 innr public abstract interface static ReturnValueNode
-intf java.lang.Iterable<javax.validation.Path$Node>
+intf java.lang.Iterable<jakarta.validation.Path$Node>
 meth public abstract java.lang.String toString()
 
-CLSS public abstract interface static javax.validation.Path$BeanNode
- outer javax.validation.Path
-intf javax.validation.Path$Node
+CLSS public abstract interface static jakarta.validation.Path$BeanNode
+ outer jakarta.validation.Path
+intf jakarta.validation.Path$Node
 meth public abstract java.lang.Class<?> getContainerClass()
 meth public abstract java.lang.Integer getTypeArgumentIndex()
 
-CLSS public abstract interface static javax.validation.Path$ConstructorNode
- outer javax.validation.Path
-intf javax.validation.Path$Node
+CLSS public abstract interface static jakarta.validation.Path$ConstructorNode
+ outer jakarta.validation.Path
+intf jakarta.validation.Path$Node
 meth public abstract java.util.List<java.lang.Class<?>> getParameterTypes()
 
-CLSS public abstract interface static javax.validation.Path$ContainerElementNode
- outer javax.validation.Path
-intf javax.validation.Path$Node
+CLSS public abstract interface static jakarta.validation.Path$ContainerElementNode
+ outer jakarta.validation.Path
+intf jakarta.validation.Path$Node
 meth public abstract java.lang.Class<?> getContainerClass()
 meth public abstract java.lang.Integer getTypeArgumentIndex()
 
-CLSS public abstract interface static javax.validation.Path$CrossParameterNode
- outer javax.validation.Path
-intf javax.validation.Path$Node
+CLSS public abstract interface static jakarta.validation.Path$CrossParameterNode
+ outer jakarta.validation.Path
+intf jakarta.validation.Path$Node
 
-CLSS public abstract interface static javax.validation.Path$MethodNode
- outer javax.validation.Path
-intf javax.validation.Path$Node
+CLSS public abstract interface static jakarta.validation.Path$MethodNode
+ outer jakarta.validation.Path
+intf jakarta.validation.Path$Node
 meth public abstract java.util.List<java.lang.Class<?>> getParameterTypes()
 
-CLSS public abstract interface static javax.validation.Path$Node
- outer javax.validation.Path
-meth public abstract <%0 extends javax.validation.Path$Node> {%%0} as(java.lang.Class<{%%0}>)
+CLSS public abstract interface static jakarta.validation.Path$Node
+ outer jakarta.validation.Path
+meth public abstract <%0 extends jakarta.validation.Path$Node> {%%0} as(java.lang.Class<{%%0}>)
 meth public abstract boolean isInIterable()
 meth public abstract java.lang.Integer getIndex()
 meth public abstract java.lang.Object getKey()
 meth public abstract java.lang.String getName()
 meth public abstract java.lang.String toString()
-meth public abstract javax.validation.ElementKind getKind()
+meth public abstract jakarta.validation.ElementKind getKind()
 
-CLSS public abstract interface static javax.validation.Path$ParameterNode
- outer javax.validation.Path
-intf javax.validation.Path$Node
+CLSS public abstract interface static jakarta.validation.Path$ParameterNode
+ outer jakarta.validation.Path
+intf jakarta.validation.Path$Node
 meth public abstract int getParameterIndex()
 
-CLSS public abstract interface static javax.validation.Path$PropertyNode
- outer javax.validation.Path
-intf javax.validation.Path$Node
+CLSS public abstract interface static jakarta.validation.Path$PropertyNode
+ outer jakarta.validation.Path
+intf jakarta.validation.Path$Node
 meth public abstract java.lang.Class<?> getContainerClass()
 meth public abstract java.lang.Integer getTypeArgumentIndex()
 
-CLSS public abstract interface static javax.validation.Path$ReturnValueNode
- outer javax.validation.Path
-intf javax.validation.Path$Node
+CLSS public abstract interface static jakarta.validation.Path$ReturnValueNode
+ outer jakarta.validation.Path
+intf jakarta.validation.Path$Node
 
-CLSS public abstract interface javax.validation.Payload
+CLSS public abstract interface jakarta.validation.Payload
 
-CLSS public abstract interface !annotation javax.validation.ReportAsSingleViolation
+CLSS public abstract interface !annotation jakarta.validation.ReportAsSingleViolation
  anno 0 java.lang.annotation.Documented()
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[ANNOTATION_TYPE])
 intf java.lang.annotation.Annotation
 
-CLSS public abstract interface javax.validation.TraversableResolver
-meth public abstract boolean isCascadable(java.lang.Object,javax.validation.Path$Node,java.lang.Class<?>,javax.validation.Path,java.lang.annotation.ElementType)
-meth public abstract boolean isReachable(java.lang.Object,javax.validation.Path$Node,java.lang.Class<?>,javax.validation.Path,java.lang.annotation.ElementType)
+CLSS public abstract interface jakarta.validation.TraversableResolver
+meth public abstract boolean isCascadable(java.lang.Object,jakarta.validation.Path$Node,java.lang.Class<?>,jakarta.validation.Path,java.lang.annotation.ElementType)
+meth public abstract boolean isReachable(java.lang.Object,jakarta.validation.Path$Node,java.lang.Class<?>,jakarta.validation.Path,java.lang.annotation.ElementType)
 
-CLSS public javax.validation.UnexpectedTypeException
+CLSS public jakarta.validation.UnexpectedTypeException
 cons public init()
 cons public init(java.lang.String)
 cons public init(java.lang.String,java.lang.Throwable)
 cons public init(java.lang.Throwable)
-supr javax.validation.ConstraintDeclarationException
+supr jakarta.validation.ConstraintDeclarationException
 
-CLSS public abstract interface !annotation javax.validation.Valid
+CLSS public abstract interface !annotation jakarta.validation.Valid
  anno 0 java.lang.annotation.Documented()
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[METHOD, FIELD, CONSTRUCTOR, PARAMETER, TYPE_USE])
 intf java.lang.annotation.Annotation
 
-CLSS public javax.validation.Validation
+CLSS public jakarta.validation.Validation
 cons public init()
-meth public static <%0 extends javax.validation.Configuration<{%%0}>, %1 extends javax.validation.spi.ValidationProvider<{%%0}>> javax.validation.bootstrap.ProviderSpecificBootstrap<{%%0}> byProvider(java.lang.Class<{%%1}>)
-meth public static javax.validation.ValidatorFactory buildDefaultValidatorFactory()
-meth public static javax.validation.bootstrap.GenericBootstrap byDefaultProvider()
+meth public static <%0 extends jakarta.validation.Configuration<{%%0}>, %1 extends jakarta.validation.spi.ValidationProvider<{%%0}>> jakarta.validation.bootstrap.ProviderSpecificBootstrap<{%%0}> byProvider(java.lang.Class<{%%1}>)
+meth public static jakarta.validation.ValidatorFactory buildDefaultValidatorFactory()
+meth public static jakarta.validation.bootstrap.GenericBootstrap byDefaultProvider()
 supr java.lang.Object
 hcls DefaultValidationProviderResolver,GenericBootstrapImpl,GetValidationProviderListAction,NewProviderInstance,ProviderSpecificBootstrapImpl
 
-CLSS public javax.validation.ValidationException
+CLSS public jakarta.validation.ValidationException
 cons public init()
 cons public init(java.lang.String)
 cons public init(java.lang.String,java.lang.Throwable)
 cons public init(java.lang.Throwable)
 supr java.lang.RuntimeException
 
-CLSS public abstract interface javax.validation.ValidationProviderResolver
-meth public abstract java.util.List<javax.validation.spi.ValidationProvider<?>> getValidationProviders()
+CLSS public abstract interface jakarta.validation.ValidationProviderResolver
+meth public abstract java.util.List<jakarta.validation.spi.ValidationProvider<?>> getValidationProviders()
 
-CLSS public abstract interface javax.validation.Validator
-meth public abstract !varargs <%0 extends java.lang.Object> java.util.Set<javax.validation.ConstraintViolation<{%%0}>> validate({%%0},java.lang.Class<?>[])
-meth public abstract !varargs <%0 extends java.lang.Object> java.util.Set<javax.validation.ConstraintViolation<{%%0}>> validateProperty({%%0},java.lang.String,java.lang.Class<?>[])
-meth public abstract !varargs <%0 extends java.lang.Object> java.util.Set<javax.validation.ConstraintViolation<{%%0}>> validateValue(java.lang.Class<{%%0}>,java.lang.String,java.lang.Object,java.lang.Class<?>[])
+CLSS public abstract interface jakarta.validation.Validator
+meth public abstract !varargs <%0 extends java.lang.Object> java.util.Set<jakarta.validation.ConstraintViolation<{%%0}>> validate({%%0},java.lang.Class<?>[])
+meth public abstract !varargs <%0 extends java.lang.Object> java.util.Set<jakarta.validation.ConstraintViolation<{%%0}>> validateProperty({%%0},java.lang.String,java.lang.Class<?>[])
+meth public abstract !varargs <%0 extends java.lang.Object> java.util.Set<jakarta.validation.ConstraintViolation<{%%0}>> validateValue(java.lang.Class<{%%0}>,java.lang.String,java.lang.Object,java.lang.Class<?>[])
 meth public abstract <%0 extends java.lang.Object> {%%0} unwrap(java.lang.Class<{%%0}>)
-meth public abstract javax.validation.executable.ExecutableValidator forExecutables()
-meth public abstract javax.validation.metadata.BeanDescriptor getConstraintsForClass(java.lang.Class<?>)
+meth public abstract jakarta.validation.executable.ExecutableValidator forExecutables()
+meth public abstract jakarta.validation.metadata.BeanDescriptor getConstraintsForClass(java.lang.Class<?>)
 
-CLSS public abstract interface javax.validation.ValidatorContext
-meth public abstract javax.validation.Validator getValidator()
-meth public abstract javax.validation.ValidatorContext addValueExtractor(javax.validation.valueextraction.ValueExtractor<?>)
-meth public abstract javax.validation.ValidatorContext clockProvider(javax.validation.ClockProvider)
-meth public abstract javax.validation.ValidatorContext constraintValidatorFactory(javax.validation.ConstraintValidatorFactory)
-meth public abstract javax.validation.ValidatorContext messageInterpolator(javax.validation.MessageInterpolator)
-meth public abstract javax.validation.ValidatorContext parameterNameProvider(javax.validation.ParameterNameProvider)
-meth public abstract javax.validation.ValidatorContext traversableResolver(javax.validation.TraversableResolver)
+CLSS public abstract interface jakarta.validation.ValidatorContext
+meth public abstract jakarta.validation.Validator getValidator()
+meth public abstract jakarta.validation.ValidatorContext addValueExtractor(jakarta.validation.valueextraction.ValueExtractor<?>)
+meth public abstract jakarta.validation.ValidatorContext clockProvider(jakarta.validation.ClockProvider)
+meth public abstract jakarta.validation.ValidatorContext constraintValidatorFactory(jakarta.validation.ConstraintValidatorFactory)
+meth public abstract jakarta.validation.ValidatorContext messageInterpolator(jakarta.validation.MessageInterpolator)
+meth public abstract jakarta.validation.ValidatorContext parameterNameProvider(jakarta.validation.ParameterNameProvider)
+meth public abstract jakarta.validation.ValidatorContext traversableResolver(jakarta.validation.TraversableResolver)
 
-CLSS public abstract interface javax.validation.ValidatorFactory
+CLSS public abstract interface jakarta.validation.ValidatorFactory
 intf java.lang.AutoCloseable
 meth public abstract <%0 extends java.lang.Object> {%%0} unwrap(java.lang.Class<{%%0}>)
-meth public abstract javax.validation.ClockProvider getClockProvider()
-meth public abstract javax.validation.ConstraintValidatorFactory getConstraintValidatorFactory()
-meth public abstract javax.validation.MessageInterpolator getMessageInterpolator()
-meth public abstract javax.validation.ParameterNameProvider getParameterNameProvider()
-meth public abstract javax.validation.TraversableResolver getTraversableResolver()
-meth public abstract javax.validation.Validator getValidator()
-meth public abstract javax.validation.ValidatorContext usingContext()
+meth public abstract jakarta.validation.ClockProvider getClockProvider()
+meth public abstract jakarta.validation.ConstraintValidatorFactory getConstraintValidatorFactory()
+meth public abstract jakarta.validation.MessageInterpolator getMessageInterpolator()
+meth public abstract jakarta.validation.ParameterNameProvider getParameterNameProvider()
+meth public abstract jakarta.validation.TraversableResolver getTraversableResolver()
+meth public abstract jakarta.validation.Validator getValidator()
+meth public abstract jakarta.validation.ValidatorContext usingContext()
 meth public abstract void close()
 
-CLSS public abstract interface javax.validation.bootstrap.GenericBootstrap
-meth public abstract javax.validation.Configuration<?> configure()
-meth public abstract javax.validation.bootstrap.GenericBootstrap providerResolver(javax.validation.ValidationProviderResolver)
+CLSS public abstract interface jakarta.validation.bootstrap.GenericBootstrap
+meth public abstract jakarta.validation.Configuration<?> configure()
+meth public abstract jakarta.validation.bootstrap.GenericBootstrap providerResolver(jakarta.validation.ValidationProviderResolver)
 
-CLSS public abstract interface javax.validation.bootstrap.ProviderSpecificBootstrap<%0 extends javax.validation.Configuration<{javax.validation.bootstrap.ProviderSpecificBootstrap%0}>>
-meth public abstract javax.validation.bootstrap.ProviderSpecificBootstrap<{javax.validation.bootstrap.ProviderSpecificBootstrap%0}> providerResolver(javax.validation.ValidationProviderResolver)
-meth public abstract {javax.validation.bootstrap.ProviderSpecificBootstrap%0} configure()
+CLSS public abstract interface jakarta.validation.bootstrap.ProviderSpecificBootstrap<%0 extends jakarta.validation.Configuration<{jakarta.validation.bootstrap.ProviderSpecificBootstrap%0}>>
+meth public abstract jakarta.validation.bootstrap.ProviderSpecificBootstrap<{jakarta.validation.bootstrap.ProviderSpecificBootstrap%0}> providerResolver(jakarta.validation.ValidationProviderResolver)
+meth public abstract {jakarta.validation.bootstrap.ProviderSpecificBootstrap%0} configure()
 
-CLSS public abstract interface !annotation javax.validation.constraints.AssertFalse
+CLSS public abstract interface !annotation jakarta.validation.constraints.AssertFalse
  anno 0 java.lang.annotation.Documented()
- anno 0 java.lang.annotation.Repeatable(java.lang.Class<? extends java.lang.annotation.Annotation> value=class javax.validation.constraints.AssertFalse$List)
+ anno 0 java.lang.annotation.Repeatable(java.lang.Class<? extends java.lang.annotation.Annotation> value=class jakarta.validation.constraints.AssertFalse$List)
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE])
- anno 0 javax.validation.Constraint(java.lang.Class<? extends javax.validation.ConstraintValidator<?,?>>[] validatedBy=[])
+ anno 0 jakarta.validation.Constraint(java.lang.Class<? extends jakarta.validation.ConstraintValidator<?,?>>[] validatedBy=[])
 innr public abstract interface static !annotation List
 intf java.lang.annotation.Annotation
-meth public abstract !hasdefault java.lang.Class<? extends javax.validation.Payload>[] payload()
+meth public abstract !hasdefault java.lang.Class<? extends jakarta.validation.Payload>[] payload()
 meth public abstract !hasdefault java.lang.Class<?>[] groups()
 meth public abstract !hasdefault java.lang.String message()
 
-CLSS public abstract interface static !annotation javax.validation.constraints.AssertFalse$List
- outer javax.validation.constraints.AssertFalse
+CLSS public abstract interface static !annotation jakarta.validation.constraints.AssertFalse$List
+ outer jakarta.validation.constraints.AssertFalse
  anno 0 java.lang.annotation.Documented()
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE])
 intf java.lang.annotation.Annotation
-meth public abstract javax.validation.constraints.AssertFalse[] value()
+meth public abstract jakarta.validation.constraints.AssertFalse[] value()
 
-CLSS public abstract interface !annotation javax.validation.constraints.AssertTrue
+CLSS public abstract interface !annotation jakarta.validation.constraints.AssertTrue
  anno 0 java.lang.annotation.Documented()
- anno 0 java.lang.annotation.Repeatable(java.lang.Class<? extends java.lang.annotation.Annotation> value=class javax.validation.constraints.AssertTrue$List)
+ anno 0 java.lang.annotation.Repeatable(java.lang.Class<? extends java.lang.annotation.Annotation> value=class jakarta.validation.constraints.AssertTrue$List)
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE])
- anno 0 javax.validation.Constraint(java.lang.Class<? extends javax.validation.ConstraintValidator<?,?>>[] validatedBy=[])
+ anno 0 jakarta.validation.Constraint(java.lang.Class<? extends jakarta.validation.ConstraintValidator<?,?>>[] validatedBy=[])
 innr public abstract interface static !annotation List
 intf java.lang.annotation.Annotation
-meth public abstract !hasdefault java.lang.Class<? extends javax.validation.Payload>[] payload()
+meth public abstract !hasdefault java.lang.Class<? extends jakarta.validation.Payload>[] payload()
 meth public abstract !hasdefault java.lang.Class<?>[] groups()
 meth public abstract !hasdefault java.lang.String message()
 
-CLSS public abstract interface static !annotation javax.validation.constraints.AssertTrue$List
- outer javax.validation.constraints.AssertTrue
+CLSS public abstract interface static !annotation jakarta.validation.constraints.AssertTrue$List
+ outer jakarta.validation.constraints.AssertTrue
  anno 0 java.lang.annotation.Documented()
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE])
 intf java.lang.annotation.Annotation
-meth public abstract javax.validation.constraints.AssertTrue[] value()
+meth public abstract jakarta.validation.constraints.AssertTrue[] value()
 
-CLSS public abstract interface !annotation javax.validation.constraints.DecimalMax
+CLSS public abstract interface !annotation jakarta.validation.constraints.DecimalMax
  anno 0 java.lang.annotation.Documented()
- anno 0 java.lang.annotation.Repeatable(java.lang.Class<? extends java.lang.annotation.Annotation> value=class javax.validation.constraints.DecimalMax$List)
+ anno 0 java.lang.annotation.Repeatable(java.lang.Class<? extends java.lang.annotation.Annotation> value=class jakarta.validation.constraints.DecimalMax$List)
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE])
- anno 0 javax.validation.Constraint(java.lang.Class<? extends javax.validation.ConstraintValidator<?,?>>[] validatedBy=[])
+ anno 0 jakarta.validation.Constraint(java.lang.Class<? extends jakarta.validation.ConstraintValidator<?,?>>[] validatedBy=[])
 innr public abstract interface static !annotation List
 intf java.lang.annotation.Annotation
 meth public abstract !hasdefault boolean inclusive()
-meth public abstract !hasdefault java.lang.Class<? extends javax.validation.Payload>[] payload()
+meth public abstract !hasdefault java.lang.Class<? extends jakarta.validation.Payload>[] payload()
 meth public abstract !hasdefault java.lang.Class<?>[] groups()
 meth public abstract !hasdefault java.lang.String message()
 meth public abstract java.lang.String value()
 
-CLSS public abstract interface static !annotation javax.validation.constraints.DecimalMax$List
- outer javax.validation.constraints.DecimalMax
+CLSS public abstract interface static !annotation jakarta.validation.constraints.DecimalMax$List
+ outer jakarta.validation.constraints.DecimalMax
  anno 0 java.lang.annotation.Documented()
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE])
 intf java.lang.annotation.Annotation
-meth public abstract javax.validation.constraints.DecimalMax[] value()
+meth public abstract jakarta.validation.constraints.DecimalMax[] value()
 
-CLSS public abstract interface !annotation javax.validation.constraints.DecimalMin
+CLSS public abstract interface !annotation jakarta.validation.constraints.DecimalMin
  anno 0 java.lang.annotation.Documented()
- anno 0 java.lang.annotation.Repeatable(java.lang.Class<? extends java.lang.annotation.Annotation> value=class javax.validation.constraints.DecimalMin$List)
+ anno 0 java.lang.annotation.Repeatable(java.lang.Class<? extends java.lang.annotation.Annotation> value=class jakarta.validation.constraints.DecimalMin$List)
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE])
- anno 0 javax.validation.Constraint(java.lang.Class<? extends javax.validation.ConstraintValidator<?,?>>[] validatedBy=[])
+ anno 0 jakarta.validation.Constraint(java.lang.Class<? extends jakarta.validation.ConstraintValidator<?,?>>[] validatedBy=[])
 innr public abstract interface static !annotation List
 intf java.lang.annotation.Annotation
 meth public abstract !hasdefault boolean inclusive()
-meth public abstract !hasdefault java.lang.Class<? extends javax.validation.Payload>[] payload()
+meth public abstract !hasdefault java.lang.Class<? extends jakarta.validation.Payload>[] payload()
 meth public abstract !hasdefault java.lang.Class<?>[] groups()
 meth public abstract !hasdefault java.lang.String message()
 meth public abstract java.lang.String value()
 
-CLSS public abstract interface static !annotation javax.validation.constraints.DecimalMin$List
- outer javax.validation.constraints.DecimalMin
+CLSS public abstract interface static !annotation jakarta.validation.constraints.DecimalMin$List
+ outer jakarta.validation.constraints.DecimalMin
  anno 0 java.lang.annotation.Documented()
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE])
 intf java.lang.annotation.Annotation
-meth public abstract javax.validation.constraints.DecimalMin[] value()
+meth public abstract jakarta.validation.constraints.DecimalMin[] value()
 
-CLSS public abstract interface !annotation javax.validation.constraints.Digits
+CLSS public abstract interface !annotation jakarta.validation.constraints.Digits
  anno 0 java.lang.annotation.Documented()
- anno 0 java.lang.annotation.Repeatable(java.lang.Class<? extends java.lang.annotation.Annotation> value=class javax.validation.constraints.Digits$List)
+ anno 0 java.lang.annotation.Repeatable(java.lang.Class<? extends java.lang.annotation.Annotation> value=class jakarta.validation.constraints.Digits$List)
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE])
- anno 0 javax.validation.Constraint(java.lang.Class<? extends javax.validation.ConstraintValidator<?,?>>[] validatedBy=[])
+ anno 0 jakarta.validation.Constraint(java.lang.Class<? extends jakarta.validation.ConstraintValidator<?,?>>[] validatedBy=[])
 innr public abstract interface static !annotation List
 intf java.lang.annotation.Annotation
-meth public abstract !hasdefault java.lang.Class<? extends javax.validation.Payload>[] payload()
+meth public abstract !hasdefault java.lang.Class<? extends jakarta.validation.Payload>[] payload()
 meth public abstract !hasdefault java.lang.Class<?>[] groups()
 meth public abstract !hasdefault java.lang.String message()
 meth public abstract int fraction()
 meth public abstract int integer()
 
-CLSS public abstract interface static !annotation javax.validation.constraints.Digits$List
- outer javax.validation.constraints.Digits
+CLSS public abstract interface static !annotation jakarta.validation.constraints.Digits$List
+ outer jakarta.validation.constraints.Digits
  anno 0 java.lang.annotation.Documented()
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE])
 intf java.lang.annotation.Annotation
-meth public abstract javax.validation.constraints.Digits[] value()
+meth public abstract jakarta.validation.constraints.Digits[] value()
 
-CLSS public abstract interface !annotation javax.validation.constraints.Email
+CLSS public abstract interface !annotation jakarta.validation.constraints.Email
  anno 0 java.lang.annotation.Documented()
- anno 0 java.lang.annotation.Repeatable(java.lang.Class<? extends java.lang.annotation.Annotation> value=class javax.validation.constraints.Email$List)
+ anno 0 java.lang.annotation.Repeatable(java.lang.Class<? extends java.lang.annotation.Annotation> value=class jakarta.validation.constraints.Email$List)
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE])
- anno 0 javax.validation.Constraint(java.lang.Class<? extends javax.validation.ConstraintValidator<?,?>>[] validatedBy=[])
+ anno 0 jakarta.validation.Constraint(java.lang.Class<? extends jakarta.validation.ConstraintValidator<?,?>>[] validatedBy=[])
 innr public abstract interface static !annotation List
 intf java.lang.annotation.Annotation
-meth public abstract !hasdefault java.lang.Class<? extends javax.validation.Payload>[] payload()
+meth public abstract !hasdefault java.lang.Class<? extends jakarta.validation.Payload>[] payload()
 meth public abstract !hasdefault java.lang.Class<?>[] groups()
 meth public abstract !hasdefault java.lang.String message()
 meth public abstract !hasdefault java.lang.String regexp()
-meth public abstract !hasdefault javax.validation.constraints.Pattern$Flag[] flags()
+meth public abstract !hasdefault jakarta.validation.constraints.Pattern$Flag[] flags()
 
-CLSS public abstract interface static !annotation javax.validation.constraints.Email$List
- outer javax.validation.constraints.Email
+CLSS public abstract interface static !annotation jakarta.validation.constraints.Email$List
+ outer jakarta.validation.constraints.Email
  anno 0 java.lang.annotation.Documented()
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE])
 intf java.lang.annotation.Annotation
-meth public abstract javax.validation.constraints.Email[] value()
+meth public abstract jakarta.validation.constraints.Email[] value()
 
-CLSS public abstract interface !annotation javax.validation.constraints.Future
+CLSS public abstract interface !annotation jakarta.validation.constraints.Future
  anno 0 java.lang.annotation.Documented()
- anno 0 java.lang.annotation.Repeatable(java.lang.Class<? extends java.lang.annotation.Annotation> value=class javax.validation.constraints.Future$List)
+ anno 0 java.lang.annotation.Repeatable(java.lang.Class<? extends java.lang.annotation.Annotation> value=class jakarta.validation.constraints.Future$List)
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE])
- anno 0 javax.validation.Constraint(java.lang.Class<? extends javax.validation.ConstraintValidator<?,?>>[] validatedBy=[])
+ anno 0 jakarta.validation.Constraint(java.lang.Class<? extends jakarta.validation.ConstraintValidator<?,?>>[] validatedBy=[])
 innr public abstract interface static !annotation List
 intf java.lang.annotation.Annotation
-meth public abstract !hasdefault java.lang.Class<? extends javax.validation.Payload>[] payload()
+meth public abstract !hasdefault java.lang.Class<? extends jakarta.validation.Payload>[] payload()
 meth public abstract !hasdefault java.lang.Class<?>[] groups()
 meth public abstract !hasdefault java.lang.String message()
 
-CLSS public abstract interface static !annotation javax.validation.constraints.Future$List
- outer javax.validation.constraints.Future
+CLSS public abstract interface static !annotation jakarta.validation.constraints.Future$List
+ outer jakarta.validation.constraints.Future
  anno 0 java.lang.annotation.Documented()
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE])
 intf java.lang.annotation.Annotation
-meth public abstract javax.validation.constraints.Future[] value()
+meth public abstract jakarta.validation.constraints.Future[] value()
 
-CLSS public abstract interface !annotation javax.validation.constraints.FutureOrPresent
+CLSS public abstract interface !annotation jakarta.validation.constraints.FutureOrPresent
  anno 0 java.lang.annotation.Documented()
- anno 0 java.lang.annotation.Repeatable(java.lang.Class<? extends java.lang.annotation.Annotation> value=class javax.validation.constraints.FutureOrPresent$List)
+ anno 0 java.lang.annotation.Repeatable(java.lang.Class<? extends java.lang.annotation.Annotation> value=class jakarta.validation.constraints.FutureOrPresent$List)
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE])
- anno 0 javax.validation.Constraint(java.lang.Class<? extends javax.validation.ConstraintValidator<?,?>>[] validatedBy=[])
+ anno 0 jakarta.validation.Constraint(java.lang.Class<? extends jakarta.validation.ConstraintValidator<?,?>>[] validatedBy=[])
 innr public abstract interface static !annotation List
 intf java.lang.annotation.Annotation
-meth public abstract !hasdefault java.lang.Class<? extends javax.validation.Payload>[] payload()
+meth public abstract !hasdefault java.lang.Class<? extends jakarta.validation.Payload>[] payload()
 meth public abstract !hasdefault java.lang.Class<?>[] groups()
 meth public abstract !hasdefault java.lang.String message()
 
-CLSS public abstract interface static !annotation javax.validation.constraints.FutureOrPresent$List
- outer javax.validation.constraints.FutureOrPresent
+CLSS public abstract interface static !annotation jakarta.validation.constraints.FutureOrPresent$List
+ outer jakarta.validation.constraints.FutureOrPresent
  anno 0 java.lang.annotation.Documented()
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE])
 intf java.lang.annotation.Annotation
-meth public abstract javax.validation.constraints.FutureOrPresent[] value()
+meth public abstract jakarta.validation.constraints.FutureOrPresent[] value()
 
-CLSS public abstract interface !annotation javax.validation.constraints.Max
+CLSS public abstract interface !annotation jakarta.validation.constraints.Max
  anno 0 java.lang.annotation.Documented()
- anno 0 java.lang.annotation.Repeatable(java.lang.Class<? extends java.lang.annotation.Annotation> value=class javax.validation.constraints.Max$List)
+ anno 0 java.lang.annotation.Repeatable(java.lang.Class<? extends java.lang.annotation.Annotation> value=class jakarta.validation.constraints.Max$List)
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE])
- anno 0 javax.validation.Constraint(java.lang.Class<? extends javax.validation.ConstraintValidator<?,?>>[] validatedBy=[])
+ anno 0 jakarta.validation.Constraint(java.lang.Class<? extends jakarta.validation.ConstraintValidator<?,?>>[] validatedBy=[])
 innr public abstract interface static !annotation List
 intf java.lang.annotation.Annotation
-meth public abstract !hasdefault java.lang.Class<? extends javax.validation.Payload>[] payload()
-meth public abstract !hasdefault java.lang.Class<?>[] groups()
-meth public abstract !hasdefault java.lang.String message()
-meth public abstract long value()
-
-CLSS public abstract interface static !annotation javax.validation.constraints.Max$List
- outer javax.validation.constraints.Max
- anno 0 java.lang.annotation.Documented()
- anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
- anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE])
-intf java.lang.annotation.Annotation
-meth public abstract javax.validation.constraints.Max[] value()
-
-CLSS public abstract interface !annotation javax.validation.constraints.Min
- anno 0 java.lang.annotation.Documented()
- anno 0 java.lang.annotation.Repeatable(java.lang.Class<? extends java.lang.annotation.Annotation> value=class javax.validation.constraints.Min$List)
- anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
- anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE])
- anno 0 javax.validation.Constraint(java.lang.Class<? extends javax.validation.ConstraintValidator<?,?>>[] validatedBy=[])
-innr public abstract interface static !annotation List
-intf java.lang.annotation.Annotation
-meth public abstract !hasdefault java.lang.Class<? extends javax.validation.Payload>[] payload()
+meth public abstract !hasdefault java.lang.Class<? extends jakarta.validation.Payload>[] payload()
 meth public abstract !hasdefault java.lang.Class<?>[] groups()
 meth public abstract !hasdefault java.lang.String message()
 meth public abstract long value()
 
-CLSS public abstract interface static !annotation javax.validation.constraints.Min$List
- outer javax.validation.constraints.Min
+CLSS public abstract interface static !annotation jakarta.validation.constraints.Max$List
+ outer jakarta.validation.constraints.Max
  anno 0 java.lang.annotation.Documented()
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE])
 intf java.lang.annotation.Annotation
-meth public abstract javax.validation.constraints.Min[] value()
+meth public abstract jakarta.validation.constraints.Max[] value()
 
-CLSS public abstract interface !annotation javax.validation.constraints.Negative
+CLSS public abstract interface !annotation jakarta.validation.constraints.Min
  anno 0 java.lang.annotation.Documented()
- anno 0 java.lang.annotation.Repeatable(java.lang.Class<? extends java.lang.annotation.Annotation> value=class javax.validation.constraints.Negative$List)
+ anno 0 java.lang.annotation.Repeatable(java.lang.Class<? extends java.lang.annotation.Annotation> value=class jakarta.validation.constraints.Min$List)
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE])
- anno 0 javax.validation.Constraint(java.lang.Class<? extends javax.validation.ConstraintValidator<?,?>>[] validatedBy=[])
+ anno 0 jakarta.validation.Constraint(java.lang.Class<? extends jakarta.validation.ConstraintValidator<?,?>>[] validatedBy=[])
 innr public abstract interface static !annotation List
 intf java.lang.annotation.Annotation
-meth public abstract !hasdefault java.lang.Class<? extends javax.validation.Payload>[] payload()
+meth public abstract !hasdefault java.lang.Class<? extends jakarta.validation.Payload>[] payload()
+meth public abstract !hasdefault java.lang.Class<?>[] groups()
+meth public abstract !hasdefault java.lang.String message()
+meth public abstract long value()
+
+CLSS public abstract interface static !annotation jakarta.validation.constraints.Min$List
+ outer jakarta.validation.constraints.Min
+ anno 0 java.lang.annotation.Documented()
+ anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
+ anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE])
+intf java.lang.annotation.Annotation
+meth public abstract jakarta.validation.constraints.Min[] value()
+
+CLSS public abstract interface !annotation jakarta.validation.constraints.Negative
+ anno 0 java.lang.annotation.Documented()
+ anno 0 java.lang.annotation.Repeatable(java.lang.Class<? extends java.lang.annotation.Annotation> value=class jakarta.validation.constraints.Negative$List)
+ anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
+ anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE])
+ anno 0 jakarta.validation.Constraint(java.lang.Class<? extends jakarta.validation.ConstraintValidator<?,?>>[] validatedBy=[])
+innr public abstract interface static !annotation List
+intf java.lang.annotation.Annotation
+meth public abstract !hasdefault java.lang.Class<? extends jakarta.validation.Payload>[] payload()
 meth public abstract !hasdefault java.lang.Class<?>[] groups()
 meth public abstract !hasdefault java.lang.String message()
 
-CLSS public abstract interface static !annotation javax.validation.constraints.Negative$List
- outer javax.validation.constraints.Negative
+CLSS public abstract interface static !annotation jakarta.validation.constraints.Negative$List
+ outer jakarta.validation.constraints.Negative
  anno 0 java.lang.annotation.Documented()
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE])
 intf java.lang.annotation.Annotation
-meth public abstract javax.validation.constraints.Negative[] value()
+meth public abstract jakarta.validation.constraints.Negative[] value()
 
-CLSS public abstract interface !annotation javax.validation.constraints.NegativeOrZero
+CLSS public abstract interface !annotation jakarta.validation.constraints.NegativeOrZero
  anno 0 java.lang.annotation.Documented()
- anno 0 java.lang.annotation.Repeatable(java.lang.Class<? extends java.lang.annotation.Annotation> value=class javax.validation.constraints.NegativeOrZero$List)
+ anno 0 java.lang.annotation.Repeatable(java.lang.Class<? extends java.lang.annotation.Annotation> value=class jakarta.validation.constraints.NegativeOrZero$List)
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE])
- anno 0 javax.validation.Constraint(java.lang.Class<? extends javax.validation.ConstraintValidator<?,?>>[] validatedBy=[])
+ anno 0 jakarta.validation.Constraint(java.lang.Class<? extends jakarta.validation.ConstraintValidator<?,?>>[] validatedBy=[])
 innr public abstract interface static !annotation List
 intf java.lang.annotation.Annotation
-meth public abstract !hasdefault java.lang.Class<? extends javax.validation.Payload>[] payload()
+meth public abstract !hasdefault java.lang.Class<? extends jakarta.validation.Payload>[] payload()
 meth public abstract !hasdefault java.lang.Class<?>[] groups()
 meth public abstract !hasdefault java.lang.String message()
 
-CLSS public abstract interface static !annotation javax.validation.constraints.NegativeOrZero$List
- outer javax.validation.constraints.NegativeOrZero
+CLSS public abstract interface static !annotation jakarta.validation.constraints.NegativeOrZero$List
+ outer jakarta.validation.constraints.NegativeOrZero
  anno 0 java.lang.annotation.Documented()
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE])
 intf java.lang.annotation.Annotation
-meth public abstract javax.validation.constraints.NegativeOrZero[] value()
+meth public abstract jakarta.validation.constraints.NegativeOrZero[] value()
 
-CLSS public abstract interface !annotation javax.validation.constraints.NotBlank
+CLSS public abstract interface !annotation jakarta.validation.constraints.NotBlank
  anno 0 java.lang.annotation.Documented()
- anno 0 java.lang.annotation.Repeatable(java.lang.Class<? extends java.lang.annotation.Annotation> value=class javax.validation.constraints.NotBlank$List)
+ anno 0 java.lang.annotation.Repeatable(java.lang.Class<? extends java.lang.annotation.Annotation> value=class jakarta.validation.constraints.NotBlank$List)
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE])
- anno 0 javax.validation.Constraint(java.lang.Class<? extends javax.validation.ConstraintValidator<?,?>>[] validatedBy=[])
+ anno 0 jakarta.validation.Constraint(java.lang.Class<? extends jakarta.validation.ConstraintValidator<?,?>>[] validatedBy=[])
 innr public abstract interface static !annotation List
 intf java.lang.annotation.Annotation
-meth public abstract !hasdefault java.lang.Class<? extends javax.validation.Payload>[] payload()
+meth public abstract !hasdefault java.lang.Class<? extends jakarta.validation.Payload>[] payload()
 meth public abstract !hasdefault java.lang.Class<?>[] groups()
 meth public abstract !hasdefault java.lang.String message()
 
-CLSS public abstract interface static !annotation javax.validation.constraints.NotBlank$List
- outer javax.validation.constraints.NotBlank
+CLSS public abstract interface static !annotation jakarta.validation.constraints.NotBlank$List
+ outer jakarta.validation.constraints.NotBlank
  anno 0 java.lang.annotation.Documented()
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE])
 intf java.lang.annotation.Annotation
-meth public abstract javax.validation.constraints.NotBlank[] value()
+meth public abstract jakarta.validation.constraints.NotBlank[] value()
 
-CLSS public abstract interface !annotation javax.validation.constraints.NotEmpty
+CLSS public abstract interface !annotation jakarta.validation.constraints.NotEmpty
  anno 0 java.lang.annotation.Documented()
- anno 0 java.lang.annotation.Repeatable(java.lang.Class<? extends java.lang.annotation.Annotation> value=class javax.validation.constraints.NotEmpty$List)
+ anno 0 java.lang.annotation.Repeatable(java.lang.Class<? extends java.lang.annotation.Annotation> value=class jakarta.validation.constraints.NotEmpty$List)
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE])
- anno 0 javax.validation.Constraint(java.lang.Class<? extends javax.validation.ConstraintValidator<?,?>>[] validatedBy=[])
+ anno 0 jakarta.validation.Constraint(java.lang.Class<? extends jakarta.validation.ConstraintValidator<?,?>>[] validatedBy=[])
 innr public abstract interface static !annotation List
 intf java.lang.annotation.Annotation
-meth public abstract !hasdefault java.lang.Class<? extends javax.validation.Payload>[] payload()
+meth public abstract !hasdefault java.lang.Class<? extends jakarta.validation.Payload>[] payload()
 meth public abstract !hasdefault java.lang.Class<?>[] groups()
 meth public abstract !hasdefault java.lang.String message()
 
-CLSS public abstract interface static !annotation javax.validation.constraints.NotEmpty$List
- outer javax.validation.constraints.NotEmpty
+CLSS public abstract interface static !annotation jakarta.validation.constraints.NotEmpty$List
+ outer jakarta.validation.constraints.NotEmpty
  anno 0 java.lang.annotation.Documented()
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE])
 intf java.lang.annotation.Annotation
-meth public abstract javax.validation.constraints.NotEmpty[] value()
+meth public abstract jakarta.validation.constraints.NotEmpty[] value()
 
-CLSS public abstract interface !annotation javax.validation.constraints.NotNull
+CLSS public abstract interface !annotation jakarta.validation.constraints.NotNull
  anno 0 java.lang.annotation.Documented()
- anno 0 java.lang.annotation.Repeatable(java.lang.Class<? extends java.lang.annotation.Annotation> value=class javax.validation.constraints.NotNull$List)
+ anno 0 java.lang.annotation.Repeatable(java.lang.Class<? extends java.lang.annotation.Annotation> value=class jakarta.validation.constraints.NotNull$List)
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE])
- anno 0 javax.validation.Constraint(java.lang.Class<? extends javax.validation.ConstraintValidator<?,?>>[] validatedBy=[])
+ anno 0 jakarta.validation.Constraint(java.lang.Class<? extends jakarta.validation.ConstraintValidator<?,?>>[] validatedBy=[])
 innr public abstract interface static !annotation List
 intf java.lang.annotation.Annotation
-meth public abstract !hasdefault java.lang.Class<? extends javax.validation.Payload>[] payload()
+meth public abstract !hasdefault java.lang.Class<? extends jakarta.validation.Payload>[] payload()
 meth public abstract !hasdefault java.lang.Class<?>[] groups()
 meth public abstract !hasdefault java.lang.String message()
 
-CLSS public abstract interface static !annotation javax.validation.constraints.NotNull$List
- outer javax.validation.constraints.NotNull
+CLSS public abstract interface static !annotation jakarta.validation.constraints.NotNull$List
+ outer jakarta.validation.constraints.NotNull
  anno 0 java.lang.annotation.Documented()
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE])
 intf java.lang.annotation.Annotation
-meth public abstract javax.validation.constraints.NotNull[] value()
+meth public abstract jakarta.validation.constraints.NotNull[] value()
 
-CLSS public abstract interface !annotation javax.validation.constraints.Null
+CLSS public abstract interface !annotation jakarta.validation.constraints.Null
  anno 0 java.lang.annotation.Documented()
- anno 0 java.lang.annotation.Repeatable(java.lang.Class<? extends java.lang.annotation.Annotation> value=class javax.validation.constraints.Null$List)
+ anno 0 java.lang.annotation.Repeatable(java.lang.Class<? extends java.lang.annotation.Annotation> value=class jakarta.validation.constraints.Null$List)
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE])
- anno 0 javax.validation.Constraint(java.lang.Class<? extends javax.validation.ConstraintValidator<?,?>>[] validatedBy=[])
+ anno 0 jakarta.validation.Constraint(java.lang.Class<? extends jakarta.validation.ConstraintValidator<?,?>>[] validatedBy=[])
 innr public abstract interface static !annotation List
 intf java.lang.annotation.Annotation
-meth public abstract !hasdefault java.lang.Class<? extends javax.validation.Payload>[] payload()
+meth public abstract !hasdefault java.lang.Class<? extends jakarta.validation.Payload>[] payload()
 meth public abstract !hasdefault java.lang.Class<?>[] groups()
 meth public abstract !hasdefault java.lang.String message()
 
-CLSS public abstract interface static !annotation javax.validation.constraints.Null$List
- outer javax.validation.constraints.Null
+CLSS public abstract interface static !annotation jakarta.validation.constraints.Null$List
+ outer jakarta.validation.constraints.Null
  anno 0 java.lang.annotation.Documented()
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE])
 intf java.lang.annotation.Annotation
-meth public abstract javax.validation.constraints.Null[] value()
+meth public abstract jakarta.validation.constraints.Null[] value()
 
-CLSS public abstract interface !annotation javax.validation.constraints.Past
+CLSS public abstract interface !annotation jakarta.validation.constraints.Past
  anno 0 java.lang.annotation.Documented()
- anno 0 java.lang.annotation.Repeatable(java.lang.Class<? extends java.lang.annotation.Annotation> value=class javax.validation.constraints.Past$List)
+ anno 0 java.lang.annotation.Repeatable(java.lang.Class<? extends java.lang.annotation.Annotation> value=class jakarta.validation.constraints.Past$List)
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE])
- anno 0 javax.validation.Constraint(java.lang.Class<? extends javax.validation.ConstraintValidator<?,?>>[] validatedBy=[])
+ anno 0 jakarta.validation.Constraint(java.lang.Class<? extends jakarta.validation.ConstraintValidator<?,?>>[] validatedBy=[])
 innr public abstract interface static !annotation List
 intf java.lang.annotation.Annotation
-meth public abstract !hasdefault java.lang.Class<? extends javax.validation.Payload>[] payload()
+meth public abstract !hasdefault java.lang.Class<? extends jakarta.validation.Payload>[] payload()
 meth public abstract !hasdefault java.lang.Class<?>[] groups()
 meth public abstract !hasdefault java.lang.String message()
 
-CLSS public abstract interface static !annotation javax.validation.constraints.Past$List
- outer javax.validation.constraints.Past
+CLSS public abstract interface static !annotation jakarta.validation.constraints.Past$List
+ outer jakarta.validation.constraints.Past
  anno 0 java.lang.annotation.Documented()
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE])
 intf java.lang.annotation.Annotation
-meth public abstract javax.validation.constraints.Past[] value()
+meth public abstract jakarta.validation.constraints.Past[] value()
 
-CLSS public abstract interface !annotation javax.validation.constraints.PastOrPresent
+CLSS public abstract interface !annotation jakarta.validation.constraints.PastOrPresent
  anno 0 java.lang.annotation.Documented()
- anno 0 java.lang.annotation.Repeatable(java.lang.Class<? extends java.lang.annotation.Annotation> value=class javax.validation.constraints.PastOrPresent$List)
+ anno 0 java.lang.annotation.Repeatable(java.lang.Class<? extends java.lang.annotation.Annotation> value=class jakarta.validation.constraints.PastOrPresent$List)
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE])
- anno 0 javax.validation.Constraint(java.lang.Class<? extends javax.validation.ConstraintValidator<?,?>>[] validatedBy=[])
+ anno 0 jakarta.validation.Constraint(java.lang.Class<? extends jakarta.validation.ConstraintValidator<?,?>>[] validatedBy=[])
 innr public abstract interface static !annotation List
 intf java.lang.annotation.Annotation
-meth public abstract !hasdefault java.lang.Class<? extends javax.validation.Payload>[] payload()
+meth public abstract !hasdefault java.lang.Class<? extends jakarta.validation.Payload>[] payload()
 meth public abstract !hasdefault java.lang.Class<?>[] groups()
 meth public abstract !hasdefault java.lang.String message()
 
-CLSS public abstract interface static !annotation javax.validation.constraints.PastOrPresent$List
- outer javax.validation.constraints.PastOrPresent
+CLSS public abstract interface static !annotation jakarta.validation.constraints.PastOrPresent$List
+ outer jakarta.validation.constraints.PastOrPresent
  anno 0 java.lang.annotation.Documented()
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE])
 intf java.lang.annotation.Annotation
-meth public abstract javax.validation.constraints.PastOrPresent[] value()
+meth public abstract jakarta.validation.constraints.PastOrPresent[] value()
 
-CLSS public abstract interface !annotation javax.validation.constraints.Pattern
+CLSS public abstract interface !annotation jakarta.validation.constraints.Pattern
  anno 0 java.lang.annotation.Documented()
- anno 0 java.lang.annotation.Repeatable(java.lang.Class<? extends java.lang.annotation.Annotation> value=class javax.validation.constraints.Pattern$List)
+ anno 0 java.lang.annotation.Repeatable(java.lang.Class<? extends java.lang.annotation.Annotation> value=class jakarta.validation.constraints.Pattern$List)
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE])
- anno 0 javax.validation.Constraint(java.lang.Class<? extends javax.validation.ConstraintValidator<?,?>>[] validatedBy=[])
+ anno 0 jakarta.validation.Constraint(java.lang.Class<? extends jakarta.validation.ConstraintValidator<?,?>>[] validatedBy=[])
 innr public abstract interface static !annotation List
 innr public final static !enum Flag
 intf java.lang.annotation.Annotation
-meth public abstract !hasdefault java.lang.Class<? extends javax.validation.Payload>[] payload()
+meth public abstract !hasdefault java.lang.Class<? extends jakarta.validation.Payload>[] payload()
 meth public abstract !hasdefault java.lang.Class<?>[] groups()
 meth public abstract !hasdefault java.lang.String message()
-meth public abstract !hasdefault javax.validation.constraints.Pattern$Flag[] flags()
+meth public abstract !hasdefault jakarta.validation.constraints.Pattern$Flag[] flags()
 meth public abstract java.lang.String regexp()
 
-CLSS public final static !enum javax.validation.constraints.Pattern$Flag
- outer javax.validation.constraints.Pattern
-fld public final static javax.validation.constraints.Pattern$Flag CANON_EQ
-fld public final static javax.validation.constraints.Pattern$Flag CASE_INSENSITIVE
-fld public final static javax.validation.constraints.Pattern$Flag COMMENTS
-fld public final static javax.validation.constraints.Pattern$Flag DOTALL
-fld public final static javax.validation.constraints.Pattern$Flag MULTILINE
-fld public final static javax.validation.constraints.Pattern$Flag UNICODE_CASE
-fld public final static javax.validation.constraints.Pattern$Flag UNIX_LINES
+CLSS public final static !enum jakarta.validation.constraints.Pattern$Flag
+ outer jakarta.validation.constraints.Pattern
+fld public final static jakarta.validation.constraints.Pattern$Flag CANON_EQ
+fld public final static jakarta.validation.constraints.Pattern$Flag CASE_INSENSITIVE
+fld public final static jakarta.validation.constraints.Pattern$Flag COMMENTS
+fld public final static jakarta.validation.constraints.Pattern$Flag DOTALL
+fld public final static jakarta.validation.constraints.Pattern$Flag MULTILINE
+fld public final static jakarta.validation.constraints.Pattern$Flag UNICODE_CASE
+fld public final static jakarta.validation.constraints.Pattern$Flag UNIX_LINES
 meth public int getValue()
-meth public static javax.validation.constraints.Pattern$Flag valueOf(java.lang.String)
-meth public static javax.validation.constraints.Pattern$Flag[] values()
-supr java.lang.Enum<javax.validation.constraints.Pattern$Flag>
+meth public static jakarta.validation.constraints.Pattern$Flag valueOf(java.lang.String)
+meth public static jakarta.validation.constraints.Pattern$Flag[] values()
+supr java.lang.Enum<jakarta.validation.constraints.Pattern$Flag>
 hfds value
 
-CLSS public abstract interface static !annotation javax.validation.constraints.Pattern$List
- outer javax.validation.constraints.Pattern
+CLSS public abstract interface static !annotation jakarta.validation.constraints.Pattern$List
+ outer jakarta.validation.constraints.Pattern
  anno 0 java.lang.annotation.Documented()
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE])
 intf java.lang.annotation.Annotation
-meth public abstract javax.validation.constraints.Pattern[] value()
+meth public abstract jakarta.validation.constraints.Pattern[] value()
 
-CLSS public abstract interface !annotation javax.validation.constraints.Positive
+CLSS public abstract interface !annotation jakarta.validation.constraints.Positive
  anno 0 java.lang.annotation.Documented()
- anno 0 java.lang.annotation.Repeatable(java.lang.Class<? extends java.lang.annotation.Annotation> value=class javax.validation.constraints.Positive$List)
+ anno 0 java.lang.annotation.Repeatable(java.lang.Class<? extends java.lang.annotation.Annotation> value=class jakarta.validation.constraints.Positive$List)
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE])
- anno 0 javax.validation.Constraint(java.lang.Class<? extends javax.validation.ConstraintValidator<?,?>>[] validatedBy=[])
+ anno 0 jakarta.validation.Constraint(java.lang.Class<? extends jakarta.validation.ConstraintValidator<?,?>>[] validatedBy=[])
 innr public abstract interface static !annotation List
 intf java.lang.annotation.Annotation
-meth public abstract !hasdefault java.lang.Class<? extends javax.validation.Payload>[] payload()
+meth public abstract !hasdefault java.lang.Class<? extends jakarta.validation.Payload>[] payload()
 meth public abstract !hasdefault java.lang.Class<?>[] groups()
 meth public abstract !hasdefault java.lang.String message()
 
-CLSS public abstract interface static !annotation javax.validation.constraints.Positive$List
- outer javax.validation.constraints.Positive
+CLSS public abstract interface static !annotation jakarta.validation.constraints.Positive$List
+ outer jakarta.validation.constraints.Positive
  anno 0 java.lang.annotation.Documented()
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE])
 intf java.lang.annotation.Annotation
-meth public abstract javax.validation.constraints.Positive[] value()
+meth public abstract jakarta.validation.constraints.Positive[] value()
 
-CLSS public abstract interface !annotation javax.validation.constraints.PositiveOrZero
+CLSS public abstract interface !annotation jakarta.validation.constraints.PositiveOrZero
  anno 0 java.lang.annotation.Documented()
- anno 0 java.lang.annotation.Repeatable(java.lang.Class<? extends java.lang.annotation.Annotation> value=class javax.validation.constraints.PositiveOrZero$List)
+ anno 0 java.lang.annotation.Repeatable(java.lang.Class<? extends java.lang.annotation.Annotation> value=class jakarta.validation.constraints.PositiveOrZero$List)
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE])
- anno 0 javax.validation.Constraint(java.lang.Class<? extends javax.validation.ConstraintValidator<?,?>>[] validatedBy=[])
+ anno 0 jakarta.validation.Constraint(java.lang.Class<? extends jakarta.validation.ConstraintValidator<?,?>>[] validatedBy=[])
 innr public abstract interface static !annotation List
 intf java.lang.annotation.Annotation
-meth public abstract !hasdefault java.lang.Class<? extends javax.validation.Payload>[] payload()
+meth public abstract !hasdefault java.lang.Class<? extends jakarta.validation.Payload>[] payload()
 meth public abstract !hasdefault java.lang.Class<?>[] groups()
 meth public abstract !hasdefault java.lang.String message()
 
-CLSS public abstract interface static !annotation javax.validation.constraints.PositiveOrZero$List
- outer javax.validation.constraints.PositiveOrZero
+CLSS public abstract interface static !annotation jakarta.validation.constraints.PositiveOrZero$List
+ outer jakarta.validation.constraints.PositiveOrZero
  anno 0 java.lang.annotation.Documented()
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE])
 intf java.lang.annotation.Annotation
-meth public abstract javax.validation.constraints.PositiveOrZero[] value()
+meth public abstract jakarta.validation.constraints.PositiveOrZero[] value()
 
-CLSS public abstract interface !annotation javax.validation.constraints.Size
+CLSS public abstract interface !annotation jakarta.validation.constraints.Size
  anno 0 java.lang.annotation.Documented()
- anno 0 java.lang.annotation.Repeatable(java.lang.Class<? extends java.lang.annotation.Annotation> value=class javax.validation.constraints.Size$List)
+ anno 0 java.lang.annotation.Repeatable(java.lang.Class<? extends java.lang.annotation.Annotation> value=class jakarta.validation.constraints.Size$List)
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE])
- anno 0 javax.validation.Constraint(java.lang.Class<? extends javax.validation.ConstraintValidator<?,?>>[] validatedBy=[])
+ anno 0 jakarta.validation.Constraint(java.lang.Class<? extends jakarta.validation.ConstraintValidator<?,?>>[] validatedBy=[])
 innr public abstract interface static !annotation List
 intf java.lang.annotation.Annotation
 meth public abstract !hasdefault int max()
 meth public abstract !hasdefault int min()
-meth public abstract !hasdefault java.lang.Class<? extends javax.validation.Payload>[] payload()
+meth public abstract !hasdefault java.lang.Class<? extends jakarta.validation.Payload>[] payload()
 meth public abstract !hasdefault java.lang.Class<?>[] groups()
 meth public abstract !hasdefault java.lang.String message()
 
-CLSS public abstract interface static !annotation javax.validation.constraints.Size$List
- outer javax.validation.constraints.Size
+CLSS public abstract interface static !annotation jakarta.validation.constraints.Size$List
+ outer jakarta.validation.constraints.Size
  anno 0 java.lang.annotation.Documented()
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE])
 intf java.lang.annotation.Annotation
-meth public abstract javax.validation.constraints.Size[] value()
+meth public abstract jakarta.validation.constraints.Size[] value()
 
-CLSS public abstract interface !annotation javax.validation.constraintvalidation.SupportedValidationTarget
+CLSS public abstract interface !annotation jakarta.validation.constraintvalidation.SupportedValidationTarget
  anno 0 java.lang.annotation.Documented()
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[TYPE])
 intf java.lang.annotation.Annotation
-meth public abstract javax.validation.constraintvalidation.ValidationTarget[] value()
+meth public abstract jakarta.validation.constraintvalidation.ValidationTarget[] value()
 
-CLSS public final !enum javax.validation.constraintvalidation.ValidationTarget
-fld public final static javax.validation.constraintvalidation.ValidationTarget ANNOTATED_ELEMENT
-fld public final static javax.validation.constraintvalidation.ValidationTarget PARAMETERS
-meth public static javax.validation.constraintvalidation.ValidationTarget valueOf(java.lang.String)
-meth public static javax.validation.constraintvalidation.ValidationTarget[] values()
-supr java.lang.Enum<javax.validation.constraintvalidation.ValidationTarget>
+CLSS public final !enum jakarta.validation.constraintvalidation.ValidationTarget
+fld public final static jakarta.validation.constraintvalidation.ValidationTarget ANNOTATED_ELEMENT
+fld public final static jakarta.validation.constraintvalidation.ValidationTarget PARAMETERS
+meth public static jakarta.validation.constraintvalidation.ValidationTarget valueOf(java.lang.String)
+meth public static jakarta.validation.constraintvalidation.ValidationTarget[] values()
+supr java.lang.Enum<jakarta.validation.constraintvalidation.ValidationTarget>
 
-CLSS public final !enum javax.validation.executable.ExecutableType
-fld public final static javax.validation.executable.ExecutableType ALL
-fld public final static javax.validation.executable.ExecutableType CONSTRUCTORS
-fld public final static javax.validation.executable.ExecutableType GETTER_METHODS
-fld public final static javax.validation.executable.ExecutableType IMPLICIT
-fld public final static javax.validation.executable.ExecutableType NONE
-fld public final static javax.validation.executable.ExecutableType NON_GETTER_METHODS
-meth public static javax.validation.executable.ExecutableType valueOf(java.lang.String)
-meth public static javax.validation.executable.ExecutableType[] values()
-supr java.lang.Enum<javax.validation.executable.ExecutableType>
+CLSS public final !enum jakarta.validation.executable.ExecutableType
+fld public final static jakarta.validation.executable.ExecutableType ALL
+fld public final static jakarta.validation.executable.ExecutableType CONSTRUCTORS
+fld public final static jakarta.validation.executable.ExecutableType GETTER_METHODS
+fld public final static jakarta.validation.executable.ExecutableType IMPLICIT
+fld public final static jakarta.validation.executable.ExecutableType NONE
+fld public final static jakarta.validation.executable.ExecutableType NON_GETTER_METHODS
+meth public static jakarta.validation.executable.ExecutableType valueOf(java.lang.String)
+meth public static jakarta.validation.executable.ExecutableType[] values()
+supr java.lang.Enum<jakarta.validation.executable.ExecutableType>
 
-CLSS public abstract interface javax.validation.executable.ExecutableValidator
-meth public abstract !varargs <%0 extends java.lang.Object> java.util.Set<javax.validation.ConstraintViolation<{%%0}>> validateConstructorParameters(java.lang.reflect.Constructor<? extends {%%0}>,java.lang.Object[],java.lang.Class<?>[])
-meth public abstract !varargs <%0 extends java.lang.Object> java.util.Set<javax.validation.ConstraintViolation<{%%0}>> validateConstructorReturnValue(java.lang.reflect.Constructor<? extends {%%0}>,{%%0},java.lang.Class<?>[])
-meth public abstract !varargs <%0 extends java.lang.Object> java.util.Set<javax.validation.ConstraintViolation<{%%0}>> validateParameters({%%0},java.lang.reflect.Method,java.lang.Object[],java.lang.Class<?>[])
-meth public abstract !varargs <%0 extends java.lang.Object> java.util.Set<javax.validation.ConstraintViolation<{%%0}>> validateReturnValue({%%0},java.lang.reflect.Method,java.lang.Object,java.lang.Class<?>[])
+CLSS public abstract interface jakarta.validation.executable.ExecutableValidator
+meth public abstract !varargs <%0 extends java.lang.Object> java.util.Set<jakarta.validation.ConstraintViolation<{%%0}>> validateConstructorParameters(java.lang.reflect.Constructor<? extends {%%0}>,java.lang.Object[],java.lang.Class<?>[])
+meth public abstract !varargs <%0 extends java.lang.Object> java.util.Set<jakarta.validation.ConstraintViolation<{%%0}>> validateConstructorReturnValue(java.lang.reflect.Constructor<? extends {%%0}>,{%%0},java.lang.Class<?>[])
+meth public abstract !varargs <%0 extends java.lang.Object> java.util.Set<jakarta.validation.ConstraintViolation<{%%0}>> validateParameters({%%0},java.lang.reflect.Method,java.lang.Object[],java.lang.Class<?>[])
+meth public abstract !varargs <%0 extends java.lang.Object> java.util.Set<jakarta.validation.ConstraintViolation<{%%0}>> validateReturnValue({%%0},java.lang.reflect.Method,java.lang.Object,java.lang.Class<?>[])
 
-CLSS public abstract interface !annotation javax.validation.executable.ValidateOnExecution
+CLSS public abstract interface !annotation jakarta.validation.executable.ValidateOnExecution
  anno 0 java.lang.annotation.Documented()
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[CONSTRUCTOR, METHOD, TYPE, PACKAGE])
 intf java.lang.annotation.Annotation
-meth public abstract !hasdefault javax.validation.executable.ExecutableType[] type()
+meth public abstract !hasdefault jakarta.validation.executable.ExecutableType[] type()
 
-CLSS public abstract interface !annotation javax.validation.groups.ConvertGroup
+CLSS public abstract interface !annotation jakarta.validation.groups.ConvertGroup
  anno 0 java.lang.annotation.Documented()
- anno 0 java.lang.annotation.Repeatable(java.lang.Class<? extends java.lang.annotation.Annotation> value=class javax.validation.groups.ConvertGroup$List)
+ anno 0 java.lang.annotation.Repeatable(java.lang.Class<? extends java.lang.annotation.Annotation> value=class jakarta.validation.groups.ConvertGroup$List)
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[METHOD, FIELD, CONSTRUCTOR, PARAMETER, TYPE_USE])
 innr public abstract interface static !annotation List
@@ -1050,200 +1050,200 @@ intf java.lang.annotation.Annotation
 meth public abstract !hasdefault java.lang.Class<?> from()
 meth public abstract java.lang.Class<?> to()
 
-CLSS public abstract interface static !annotation javax.validation.groups.ConvertGroup$List
- outer javax.validation.groups.ConvertGroup
+CLSS public abstract interface static !annotation jakarta.validation.groups.ConvertGroup$List
+ outer jakarta.validation.groups.ConvertGroup
  anno 0 java.lang.annotation.Documented()
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[METHOD, FIELD, CONSTRUCTOR, PARAMETER, TYPE_USE])
 intf java.lang.annotation.Annotation
-meth public abstract javax.validation.groups.ConvertGroup[] value()
+meth public abstract jakarta.validation.groups.ConvertGroup[] value()
 
-CLSS public abstract interface javax.validation.groups.Default
+CLSS public abstract interface jakarta.validation.groups.Default
 
-CLSS public abstract interface javax.validation.metadata.BeanDescriptor
-intf javax.validation.metadata.ElementDescriptor
-meth public abstract !varargs java.util.Set<javax.validation.metadata.MethodDescriptor> getConstrainedMethods(javax.validation.metadata.MethodType,javax.validation.metadata.MethodType[])
-meth public abstract !varargs javax.validation.metadata.ConstructorDescriptor getConstraintsForConstructor(java.lang.Class<?>[])
-meth public abstract !varargs javax.validation.metadata.MethodDescriptor getConstraintsForMethod(java.lang.String,java.lang.Class<?>[])
+CLSS public abstract interface jakarta.validation.metadata.BeanDescriptor
+intf jakarta.validation.metadata.ElementDescriptor
+meth public abstract !varargs java.util.Set<jakarta.validation.metadata.MethodDescriptor> getConstrainedMethods(jakarta.validation.metadata.MethodType,jakarta.validation.metadata.MethodType[])
+meth public abstract !varargs jakarta.validation.metadata.ConstructorDescriptor getConstraintsForConstructor(java.lang.Class<?>[])
+meth public abstract !varargs jakarta.validation.metadata.MethodDescriptor getConstraintsForMethod(java.lang.String,java.lang.Class<?>[])
 meth public abstract boolean isBeanConstrained()
-meth public abstract java.util.Set<javax.validation.metadata.ConstructorDescriptor> getConstrainedConstructors()
-meth public abstract java.util.Set<javax.validation.metadata.PropertyDescriptor> getConstrainedProperties()
-meth public abstract javax.validation.metadata.PropertyDescriptor getConstraintsForProperty(java.lang.String)
+meth public abstract java.util.Set<jakarta.validation.metadata.ConstructorDescriptor> getConstrainedConstructors()
+meth public abstract java.util.Set<jakarta.validation.metadata.PropertyDescriptor> getConstrainedProperties()
+meth public abstract jakarta.validation.metadata.PropertyDescriptor getConstraintsForProperty(java.lang.String)
 
-CLSS public abstract interface javax.validation.metadata.CascadableDescriptor
+CLSS public abstract interface jakarta.validation.metadata.CascadableDescriptor
 meth public abstract boolean isCascaded()
-meth public abstract java.util.Set<javax.validation.metadata.GroupConversionDescriptor> getGroupConversions()
+meth public abstract java.util.Set<jakarta.validation.metadata.GroupConversionDescriptor> getGroupConversions()
 
-CLSS public abstract interface javax.validation.metadata.ConstraintDescriptor<%0 extends java.lang.annotation.Annotation>
+CLSS public abstract interface jakarta.validation.metadata.ConstraintDescriptor<%0 extends java.lang.annotation.Annotation>
 meth public abstract <%0 extends java.lang.Object> {%%0} unwrap(java.lang.Class<{%%0}>)
 meth public abstract boolean isReportAsSingleViolation()
 meth public abstract java.lang.String getMessageTemplate()
-meth public abstract java.util.List<java.lang.Class<? extends javax.validation.ConstraintValidator<{javax.validation.metadata.ConstraintDescriptor%0},?>>> getConstraintValidatorClasses()
+meth public abstract java.util.List<java.lang.Class<? extends jakarta.validation.ConstraintValidator<{jakarta.validation.metadata.ConstraintDescriptor%0},?>>> getConstraintValidatorClasses()
 meth public abstract java.util.Map<java.lang.String,java.lang.Object> getAttributes()
-meth public abstract java.util.Set<java.lang.Class<? extends javax.validation.Payload>> getPayload()
+meth public abstract java.util.Set<java.lang.Class<? extends jakarta.validation.Payload>> getPayload()
 meth public abstract java.util.Set<java.lang.Class<?>> getGroups()
-meth public abstract java.util.Set<javax.validation.metadata.ConstraintDescriptor<?>> getComposingConstraints()
-meth public abstract javax.validation.ConstraintTarget getValidationAppliesTo()
-meth public abstract javax.validation.metadata.ValidateUnwrappedValue getValueUnwrapping()
-meth public abstract {javax.validation.metadata.ConstraintDescriptor%0} getAnnotation()
+meth public abstract java.util.Set<jakarta.validation.metadata.ConstraintDescriptor<?>> getComposingConstraints()
+meth public abstract jakarta.validation.ConstraintTarget getValidationAppliesTo()
+meth public abstract jakarta.validation.metadata.ValidateUnwrappedValue getValueUnwrapping()
+meth public abstract {jakarta.validation.metadata.ConstraintDescriptor%0} getAnnotation()
 
-CLSS public abstract interface javax.validation.metadata.ConstructorDescriptor
-intf javax.validation.metadata.ExecutableDescriptor
+CLSS public abstract interface jakarta.validation.metadata.ConstructorDescriptor
+intf jakarta.validation.metadata.ExecutableDescriptor
 
-CLSS public abstract interface javax.validation.metadata.ContainerDescriptor
-meth public abstract java.util.Set<javax.validation.metadata.ContainerElementTypeDescriptor> getConstrainedContainerElementTypes()
+CLSS public abstract interface jakarta.validation.metadata.ContainerDescriptor
+meth public abstract java.util.Set<jakarta.validation.metadata.ContainerElementTypeDescriptor> getConstrainedContainerElementTypes()
 
-CLSS public abstract interface javax.validation.metadata.ContainerElementTypeDescriptor
-intf javax.validation.metadata.CascadableDescriptor
-intf javax.validation.metadata.ContainerDescriptor
-intf javax.validation.metadata.ElementDescriptor
+CLSS public abstract interface jakarta.validation.metadata.ContainerElementTypeDescriptor
+intf jakarta.validation.metadata.CascadableDescriptor
+intf jakarta.validation.metadata.ContainerDescriptor
+intf jakarta.validation.metadata.ElementDescriptor
 meth public abstract java.lang.Class<?> getContainerClass()
 meth public abstract java.lang.Integer getTypeArgumentIndex()
 
-CLSS public abstract interface javax.validation.metadata.CrossParameterDescriptor
-intf javax.validation.metadata.ElementDescriptor
+CLSS public abstract interface jakarta.validation.metadata.CrossParameterDescriptor
+intf jakarta.validation.metadata.ElementDescriptor
 meth public abstract java.lang.Class<?> getElementClass()
 
-CLSS public abstract interface javax.validation.metadata.ElementDescriptor
+CLSS public abstract interface jakarta.validation.metadata.ElementDescriptor
 innr public abstract interface static ConstraintFinder
 meth public abstract boolean hasConstraints()
 meth public abstract java.lang.Class<?> getElementClass()
-meth public abstract java.util.Set<javax.validation.metadata.ConstraintDescriptor<?>> getConstraintDescriptors()
-meth public abstract javax.validation.metadata.ElementDescriptor$ConstraintFinder findConstraints()
+meth public abstract java.util.Set<jakarta.validation.metadata.ConstraintDescriptor<?>> getConstraintDescriptors()
+meth public abstract jakarta.validation.metadata.ElementDescriptor$ConstraintFinder findConstraints()
 
-CLSS public abstract interface static javax.validation.metadata.ElementDescriptor$ConstraintFinder
- outer javax.validation.metadata.ElementDescriptor
-meth public abstract !varargs javax.validation.metadata.ElementDescriptor$ConstraintFinder declaredOn(java.lang.annotation.ElementType[])
-meth public abstract !varargs javax.validation.metadata.ElementDescriptor$ConstraintFinder unorderedAndMatchingGroups(java.lang.Class<?>[])
+CLSS public abstract interface static jakarta.validation.metadata.ElementDescriptor$ConstraintFinder
+ outer jakarta.validation.metadata.ElementDescriptor
+meth public abstract !varargs jakarta.validation.metadata.ElementDescriptor$ConstraintFinder declaredOn(java.lang.annotation.ElementType[])
+meth public abstract !varargs jakarta.validation.metadata.ElementDescriptor$ConstraintFinder unorderedAndMatchingGroups(java.lang.Class<?>[])
 meth public abstract boolean hasConstraints()
-meth public abstract java.util.Set<javax.validation.metadata.ConstraintDescriptor<?>> getConstraintDescriptors()
-meth public abstract javax.validation.metadata.ElementDescriptor$ConstraintFinder lookingAt(javax.validation.metadata.Scope)
+meth public abstract java.util.Set<jakarta.validation.metadata.ConstraintDescriptor<?>> getConstraintDescriptors()
+meth public abstract jakarta.validation.metadata.ElementDescriptor$ConstraintFinder lookingAt(jakarta.validation.metadata.Scope)
 
-CLSS public abstract interface javax.validation.metadata.ExecutableDescriptor
-intf javax.validation.metadata.ElementDescriptor
+CLSS public abstract interface jakarta.validation.metadata.ExecutableDescriptor
+intf jakarta.validation.metadata.ElementDescriptor
 meth public abstract boolean hasConstrainedParameters()
 meth public abstract boolean hasConstrainedReturnValue()
 meth public abstract boolean hasConstraints()
 meth public abstract java.lang.String getName()
-meth public abstract java.util.List<javax.validation.metadata.ParameterDescriptor> getParameterDescriptors()
-meth public abstract java.util.Set<javax.validation.metadata.ConstraintDescriptor<?>> getConstraintDescriptors()
-meth public abstract javax.validation.metadata.CrossParameterDescriptor getCrossParameterDescriptor()
-meth public abstract javax.validation.metadata.ElementDescriptor$ConstraintFinder findConstraints()
-meth public abstract javax.validation.metadata.ReturnValueDescriptor getReturnValueDescriptor()
+meth public abstract java.util.List<jakarta.validation.metadata.ParameterDescriptor> getParameterDescriptors()
+meth public abstract java.util.Set<jakarta.validation.metadata.ConstraintDescriptor<?>> getConstraintDescriptors()
+meth public abstract jakarta.validation.metadata.CrossParameterDescriptor getCrossParameterDescriptor()
+meth public abstract jakarta.validation.metadata.ElementDescriptor$ConstraintFinder findConstraints()
+meth public abstract jakarta.validation.metadata.ReturnValueDescriptor getReturnValueDescriptor()
 
-CLSS public abstract interface javax.validation.metadata.GroupConversionDescriptor
+CLSS public abstract interface jakarta.validation.metadata.GroupConversionDescriptor
 meth public abstract java.lang.Class<?> getFrom()
 meth public abstract java.lang.Class<?> getTo()
 
-CLSS public abstract interface javax.validation.metadata.MethodDescriptor
-intf javax.validation.metadata.ExecutableDescriptor
+CLSS public abstract interface jakarta.validation.metadata.MethodDescriptor
+intf jakarta.validation.metadata.ExecutableDescriptor
 
-CLSS public final !enum javax.validation.metadata.MethodType
-fld public final static javax.validation.metadata.MethodType GETTER
-fld public final static javax.validation.metadata.MethodType NON_GETTER
-meth public static javax.validation.metadata.MethodType valueOf(java.lang.String)
-meth public static javax.validation.metadata.MethodType[] values()
-supr java.lang.Enum<javax.validation.metadata.MethodType>
+CLSS public final !enum jakarta.validation.metadata.MethodType
+fld public final static jakarta.validation.metadata.MethodType GETTER
+fld public final static jakarta.validation.metadata.MethodType NON_GETTER
+meth public static jakarta.validation.metadata.MethodType valueOf(java.lang.String)
+meth public static jakarta.validation.metadata.MethodType[] values()
+supr java.lang.Enum<jakarta.validation.metadata.MethodType>
 
-CLSS public abstract interface javax.validation.metadata.ParameterDescriptor
-intf javax.validation.metadata.CascadableDescriptor
-intf javax.validation.metadata.ContainerDescriptor
-intf javax.validation.metadata.ElementDescriptor
+CLSS public abstract interface jakarta.validation.metadata.ParameterDescriptor
+intf jakarta.validation.metadata.CascadableDescriptor
+intf jakarta.validation.metadata.ContainerDescriptor
+intf jakarta.validation.metadata.ElementDescriptor
 meth public abstract int getIndex()
 meth public abstract java.lang.String getName()
 
-CLSS public abstract interface javax.validation.metadata.PropertyDescriptor
-intf javax.validation.metadata.CascadableDescriptor
-intf javax.validation.metadata.ContainerDescriptor
-intf javax.validation.metadata.ElementDescriptor
+CLSS public abstract interface jakarta.validation.metadata.PropertyDescriptor
+intf jakarta.validation.metadata.CascadableDescriptor
+intf jakarta.validation.metadata.ContainerDescriptor
+intf jakarta.validation.metadata.ElementDescriptor
 meth public abstract java.lang.String getPropertyName()
 
-CLSS public abstract interface javax.validation.metadata.ReturnValueDescriptor
-intf javax.validation.metadata.CascadableDescriptor
-intf javax.validation.metadata.ContainerDescriptor
-intf javax.validation.metadata.ElementDescriptor
+CLSS public abstract interface jakarta.validation.metadata.ReturnValueDescriptor
+intf jakarta.validation.metadata.CascadableDescriptor
+intf jakarta.validation.metadata.ContainerDescriptor
+intf jakarta.validation.metadata.ElementDescriptor
 
-CLSS public final !enum javax.validation.metadata.Scope
-fld public final static javax.validation.metadata.Scope HIERARCHY
-fld public final static javax.validation.metadata.Scope LOCAL_ELEMENT
-meth public static javax.validation.metadata.Scope valueOf(java.lang.String)
-meth public static javax.validation.metadata.Scope[] values()
-supr java.lang.Enum<javax.validation.metadata.Scope>
+CLSS public final !enum jakarta.validation.metadata.Scope
+fld public final static jakarta.validation.metadata.Scope HIERARCHY
+fld public final static jakarta.validation.metadata.Scope LOCAL_ELEMENT
+meth public static jakarta.validation.metadata.Scope valueOf(java.lang.String)
+meth public static jakarta.validation.metadata.Scope[] values()
+supr java.lang.Enum<jakarta.validation.metadata.Scope>
 
-CLSS public final !enum javax.validation.metadata.ValidateUnwrappedValue
-fld public final static javax.validation.metadata.ValidateUnwrappedValue DEFAULT
-fld public final static javax.validation.metadata.ValidateUnwrappedValue SKIP
-fld public final static javax.validation.metadata.ValidateUnwrappedValue UNWRAP
-meth public static javax.validation.metadata.ValidateUnwrappedValue valueOf(java.lang.String)
-meth public static javax.validation.metadata.ValidateUnwrappedValue[] values()
-supr java.lang.Enum<javax.validation.metadata.ValidateUnwrappedValue>
+CLSS public final !enum jakarta.validation.metadata.ValidateUnwrappedValue
+fld public final static jakarta.validation.metadata.ValidateUnwrappedValue DEFAULT
+fld public final static jakarta.validation.metadata.ValidateUnwrappedValue SKIP
+fld public final static jakarta.validation.metadata.ValidateUnwrappedValue UNWRAP
+meth public static jakarta.validation.metadata.ValidateUnwrappedValue valueOf(java.lang.String)
+meth public static jakarta.validation.metadata.ValidateUnwrappedValue[] values()
+supr java.lang.Enum<jakarta.validation.metadata.ValidateUnwrappedValue>
 
-CLSS public abstract interface javax.validation.spi.BootstrapState
-meth public abstract javax.validation.ValidationProviderResolver getDefaultValidationProviderResolver()
-meth public abstract javax.validation.ValidationProviderResolver getValidationProviderResolver()
+CLSS public abstract interface jakarta.validation.spi.BootstrapState
+meth public abstract jakarta.validation.ValidationProviderResolver getDefaultValidationProviderResolver()
+meth public abstract jakarta.validation.ValidationProviderResolver getValidationProviderResolver()
 
-CLSS public abstract interface javax.validation.spi.ConfigurationState
+CLSS public abstract interface jakarta.validation.spi.ConfigurationState
 meth public abstract boolean isIgnoreXmlConfiguration()
 meth public abstract java.util.Map<java.lang.String,java.lang.String> getProperties()
 meth public abstract java.util.Set<java.io.InputStream> getMappingStreams()
-meth public abstract java.util.Set<javax.validation.valueextraction.ValueExtractor<?>> getValueExtractors()
-meth public abstract javax.validation.ClockProvider getClockProvider()
-meth public abstract javax.validation.ConstraintValidatorFactory getConstraintValidatorFactory()
-meth public abstract javax.validation.MessageInterpolator getMessageInterpolator()
-meth public abstract javax.validation.ParameterNameProvider getParameterNameProvider()
-meth public abstract javax.validation.TraversableResolver getTraversableResolver()
+meth public abstract java.util.Set<jakarta.validation.valueextraction.ValueExtractor<?>> getValueExtractors()
+meth public abstract jakarta.validation.ClockProvider getClockProvider()
+meth public abstract jakarta.validation.ConstraintValidatorFactory getConstraintValidatorFactory()
+meth public abstract jakarta.validation.MessageInterpolator getMessageInterpolator()
+meth public abstract jakarta.validation.ParameterNameProvider getParameterNameProvider()
+meth public abstract jakarta.validation.TraversableResolver getTraversableResolver()
 
-CLSS public abstract interface javax.validation.spi.ValidationProvider<%0 extends javax.validation.Configuration<{javax.validation.spi.ValidationProvider%0}>>
-meth public abstract javax.validation.Configuration<?> createGenericConfiguration(javax.validation.spi.BootstrapState)
-meth public abstract javax.validation.ValidatorFactory buildValidatorFactory(javax.validation.spi.ConfigurationState)
-meth public abstract {javax.validation.spi.ValidationProvider%0} createSpecializedConfiguration(javax.validation.spi.BootstrapState)
+CLSS public abstract interface jakarta.validation.spi.ValidationProvider<%0 extends jakarta.validation.Configuration<{jakarta.validation.spi.ValidationProvider%0}>>
+meth public abstract jakarta.validation.Configuration<?> createGenericConfiguration(jakarta.validation.spi.BootstrapState)
+meth public abstract jakarta.validation.ValidatorFactory buildValidatorFactory(jakarta.validation.spi.ConfigurationState)
+meth public abstract {jakarta.validation.spi.ValidationProvider%0} createSpecializedConfiguration(jakarta.validation.spi.BootstrapState)
 
-CLSS public abstract interface !annotation javax.validation.valueextraction.ExtractedValue
+CLSS public abstract interface !annotation jakarta.validation.valueextraction.ExtractedValue
  anno 0 java.lang.annotation.Documented()
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[TYPE_USE])
 intf java.lang.annotation.Annotation
 meth public abstract !hasdefault java.lang.Class<?> type()
 
-CLSS public abstract interface !annotation javax.validation.valueextraction.UnwrapByDefault
+CLSS public abstract interface !annotation jakarta.validation.valueextraction.UnwrapByDefault
  anno 0 java.lang.annotation.Documented()
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[TYPE])
 intf java.lang.annotation.Annotation
 
-CLSS public abstract interface javax.validation.valueextraction.Unwrapping
+CLSS public abstract interface jakarta.validation.valueextraction.Unwrapping
 innr public abstract interface static Skip
 innr public abstract interface static Unwrap
 
-CLSS public abstract interface static javax.validation.valueextraction.Unwrapping$Skip
- outer javax.validation.valueextraction.Unwrapping
-intf javax.validation.Payload
+CLSS public abstract interface static jakarta.validation.valueextraction.Unwrapping$Skip
+ outer jakarta.validation.valueextraction.Unwrapping
+intf jakarta.validation.Payload
 
-CLSS public abstract interface static javax.validation.valueextraction.Unwrapping$Unwrap
- outer javax.validation.valueextraction.Unwrapping
-intf javax.validation.Payload
+CLSS public abstract interface static jakarta.validation.valueextraction.Unwrapping$Unwrap
+ outer jakarta.validation.valueextraction.Unwrapping
+intf jakarta.validation.Payload
 
-CLSS public abstract interface javax.validation.valueextraction.ValueExtractor<%0 extends java.lang.Object>
+CLSS public abstract interface jakarta.validation.valueextraction.ValueExtractor<%0 extends java.lang.Object>
 innr public abstract interface static ValueReceiver
-meth public abstract void extractValues({javax.validation.valueextraction.ValueExtractor%0},javax.validation.valueextraction.ValueExtractor$ValueReceiver)
+meth public abstract void extractValues({jakarta.validation.valueextraction.ValueExtractor%0},jakarta.validation.valueextraction.ValueExtractor$ValueReceiver)
 
-CLSS public abstract interface static javax.validation.valueextraction.ValueExtractor$ValueReceiver
- outer javax.validation.valueextraction.ValueExtractor
+CLSS public abstract interface static jakarta.validation.valueextraction.ValueExtractor$ValueReceiver
+ outer jakarta.validation.valueextraction.ValueExtractor
 meth public abstract void indexedValue(java.lang.String,int,java.lang.Object)
 meth public abstract void iterableValue(java.lang.String,java.lang.Object)
 meth public abstract void keyedValue(java.lang.String,java.lang.Object,java.lang.Object)
 meth public abstract void value(java.lang.String,java.lang.Object)
 
-CLSS public javax.validation.valueextraction.ValueExtractorDeclarationException
+CLSS public jakarta.validation.valueextraction.ValueExtractorDeclarationException
 cons public init()
 cons public init(java.lang.String)
 cons public init(java.lang.String,java.lang.Throwable)
 cons public init(java.lang.Throwable)
-supr javax.validation.ValidationException
+supr jakarta.validation.ValidationException
 
-CLSS public javax.validation.valueextraction.ValueExtractorDefinitionException
+CLSS public jakarta.validation.valueextraction.ValueExtractorDefinitionException
 cons public init()
 cons public init(java.lang.String)
 cons public init(java.lang.String,java.lang.Throwable)
 cons public init(java.lang.Throwable)
-supr javax.validation.ValidationException
+supr jakarta.validation.ValidationException


### PR DESCRIPTION
We upgraded BV tck to 3.0.0-M5(from M1), Hibernate Validator to 7.0.0.Alpha4 (from Alpha1). arquillian servlet protocol and glassfish container integration( to version 1.7.0.Alpha2) were built locally and used with BV TCK run. Post these upgrade and with fixes to pom.xml (removed parallel execution of tests), we have following result:
-----------------------------------------------------------------------------------------------------------------------------------------
 [mvn.test] Tests run: 1045, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 506.454 sec - in TestSuite
----------------------------------------------------------------------------------------------------------------------------------------
CI run can be found here - https://ci.eclipse.org/jakartaee-tck/job/bvtck-porting-grao/job/master/lastCompletedBuild/testReport/

Signed-off-by: gurunandan <gurunandan.rao@oracle.com>