### PR TITLE
update hibernate validator to 7.0.0.Alpha5, also log4j

### DIFF
--- a/glassfish-tck-runner/pom.xml
+++ b/glassfish-tck-runner/pom.xml
@@ -60,7 +60,7 @@
 		<dependency>
     	<groupId>org.hibernate.validator</groupId>
     		<artifactId>hibernate-validator-cdi</artifactId>
-    		<version>7.0.0.Alpha4</version>
+    		<version>7.0.0.Alpha5</version>
   		</dependency>
 		<dependency>
 		    <groupId>jakarta.ws.rs</groupId>
@@ -75,7 +75,7 @@
         <dependency>
             <groupId>org.hibernate.validator</groupId>
             <artifactId>hibernate-validator</artifactId>
-            <version>7.0.0.Alpha4</version>
+            <version>7.0.0.Alpha5</version>
              <exclusions>
                 <exclusion>
                     <groupId>jakarta.validation</groupId>
@@ -184,12 +184,12 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.11.0</version>
+            <version>[2.13.2,)</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>2.11.0</version>
+            <version>[2.13.2,)</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Signed-off-by: Gurunandan <gurunandan.rao@oracle.com>